### PR TITLE
Fix issue #11

### DIFF
--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -80,13 +80,17 @@ nnoremap <silent> <Plug>(Jieba_preview_cancel) :<C-u>py3 jieba_vim.preview_cance
 
 for ky in s:motions
     execute 'nnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') ":<C-u>py3 jieba_vim.navigation.nmap_' . ky . '(" . v:count1 . ")<CR>"'
-    if ky ==# "e" || ky ==# "E"
-        execute 'onoremap <expr> <silent> <Plug>(Jieba_' . ky . ') "v:<C-u>py3 jieba_vim.navigation.omap_' . ky . '(\"" . v:operator . "\", " . v:count1 . ")<CR>"'
-    elseif ky ==# "b" || ky ==# "B" || ky ==# "ge" || ky ==# "gE"
-        execute 'onoremap <expr> <silent> <Plug>(Jieba_' . ky . ') "<Esc>:<C-u>py3 jieba_vim.navigation.omap_' . ky . '(\"" . v:operator . "\", " . v:count1 . ")<CR>"'
-    else
-        execute 'onoremap <expr> <silent> <Plug>(Jieba_' . ky . ') ":<C-u>py3 jieba_vim.navigation.omap_' . ky . '(\"" . v:operator . "\", " . v:count1 . ")<CR>"'
-    endif
+    execute
+        \ 'onoremap <expr> <silent> <Plug>(Jieba_'
+        \ . ky
+        \ . ') "<Esc>:<C-u>py3 jieba_vim.navigation.omap_'
+        \ . ky
+        \ . "('"
+        \ . '" . v:register . "'
+        \ . "', '"
+        \ . '" . v:operator . "'
+        \ . "', "
+        \ . '" . v:count1 . ")<CR>"'
     execute 'xnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') "<Esc>:<C-u>py3 jieba_vim.navigation.xmap_' . ky . '(" . v:count1 . ")<CR>:py3 jieba_vim.navigation.teardown_xmap_' . ky . '()<CR>"'
 endfor
 

--- a/pythonx/jieba_vim/navigation.py
+++ b/pythonx/jieba_vim/navigation.py
@@ -62,6 +62,17 @@ def upperbound_count(count):
     return min(18446744073709551615, count)
 
 
+def get_register_value(register):
+    # The register is quoted by single quotes because no register is named `'`.
+    return vim.eval("getreg('{}')".format(register))
+
+
+def set_register_value(register, value):
+    # First escape backslashes and double quotes.
+    value = value.replace('\\', '\\\\').replace('"', '\\"')
+    vim.command("call setreg('{}', \"{}\")".format(register, value))
+
+
 def _init_word_motion():
     global word_motion
     if word_motion is not None:
@@ -133,28 +144,27 @@ def _vim_wrapper_factory_omap_w(motion_name):
     assert motion_name in ['w', 'W']
     fun_name = 'omap_' + motion_name
 
-    def _motion_wrapper(operator, count):
+    def _motion_wrapper(register, operator, count):
         count = upperbound_count(count)
         method = getattr(word_motion, fun_name)
-        # virtualedit trick reference:
-        # https://github.com/svermeulen/vim-NotableFt/blob/01732102c1d8c7b7bd6e221329e37685aa4ab41a/plugin/NotableFt.vim#L242-L256
-        #
-        # I tried `let s:jieba_vim_previous_virtualedit = &virtualedit` but got
-        # error "Illegal variable name: s:jieba_vim_previous_virtualedit". Will
-        # the use of global variable lead to race condition when there are
-        # multiple instances of Vim open?
-        vim.command('let g:jieba_vim_previous_virtualedit = &virtualedit')
-        vim.command('set virtualedit=onemore')
+        virtualedit_config = vim.eval('&virtualedit')
         output = method(vim.current.buffer, vim.current.window.cursor,
                         operator, count)
-        vim.current.window.cursor = output.cursor
+        col_before = vim.current.window.cursor[1]
+        vim.command('set virtualedit=onemore')
+        # `output.cursor[1] + 1` because vim column starts from 1 whereas vim
+        # python api column starts from 0.
         vim.command(
-            'augroup jieba_vim_reset_virtualedit '
-            '| autocmd! '
-            '| autocmd TextChanged,CursorMoved <buffer> '
-            'execute "set virtualedit=" . g:jieba_vim_previous_virtualedit '
-            '| autocmd! jieba_vim_reset_virtualedit '
-            '| augroup END')
+            '''execute 'silent normal! "{}{}:call cursor({}, {})' . "\\<CR>"'''
+            .format(register, operator, output.cursor[0],
+                    output.cursor[1] + 1))
+        if operator == 'c':
+            # Running `c` in `normal!` as above will shift the cursor one more
+            # character to the left; so we need to shift back one character.
+            if col_before > 0:
+                vim.command('normal! l')
+            vim.command('startinsert')
+        vim.command('set virtualedit={}'.format(virtualedit_config))
 
     return {fun_name: _motion_wrapper}
 
@@ -163,46 +173,45 @@ def _vim_wrapper_factory_omap_e(motion_name):
     assert motion_name in ['e', 'E']
     fun_name = 'omap_' + motion_name
 
-    def _motion_wrapper(operator, count):
+    def _motion_wrapper(register, operator, count):
         count = upperbound_count(count)
         method = getattr(word_motion, fun_name)
-        # virtualedit trick reference:
-        # https://github.com/svermeulen/vim-NotableFt/blob/01732102c1d8c7b7bd6e221329e37685aa4ab41a/plugin/NotableFt.vim#L242-L256
-        #
-        # I tried `let s:jieba_vim_previous_virtualedit = &virtualedit` but got
-        # error "Illegal variable name: s:jieba_vim_previous_virtualedit". Will
-        # the use of global variable lead to race condition when there are
-        # multiple instances of Vim open?
-        vim.command('let g:jieba_vim_previous_virtualedit = &virtualedit')
-        vim.command('set virtualedit=onemore')
+        virtualedit_config = vim.eval('&virtualedit')
         output = method(vim.current.buffer, vim.current.window.cursor,
                         operator, count)
+        line_before = vim.current.window.cursor[0]
         col_before = vim.current.window.cursor[1]
-        vim.current.window.cursor = output.cursor
+        # This will be used in d-special case below.
+        chars_before_cursor = vim.current.buffer[line_before - 1][:col_before]
+        vim.command('set virtualedit=onemore')
+        # `output.cursor[1] + 1` because vim column starts from 1 whereas vim
+        # python api column starts from 0.
         vim.command(
-            'augroup jieba_vim_reset_virtualedit '
-            '| autocmd! '
-            '| autocmd TextChanged,CursorMoved <buffer> '
-            'execute "set virtualedit=" . g:jieba_vim_previous_virtualedit '
-            '| autocmd! jieba_vim_reset_virtualedit '
-            '| augroup END')
+            '''execute 'silent normal! "{}{}v:call cursor({}, {})' . "\\<CR>"'''
+            .format(register, operator, output.cursor[0],
+                    output.cursor[1] + 1))
+        reg_value = get_register_value(register)
+        if operator == 'c':
+            # Running `c` in `normal!` as above will shift the cursor one more
+            # character to the left; so we need to shift back one character.
+            if col_before:
+                vim.command('normal! l')
+            vim.command('startinsert')
         # This patch breaks `.` (see https://vimhelp.org/repeat.txt.html#.).
-        # Need help on fixing this issue.
-        if operator == 'd' and output.d_special:
-            if int(vim.eval('has("nvim")')):
-                vim.command(
-                    'augroup jieba_vim_teardown_d_special '
-                    '| autocmd! '
-                    '| autocmd TextChanged <buffer> execute "normal! dd" | execute "silent call cursor(line(\'.\'), {})" '
-                    '| autocmd! jieba_vim_teardown_d_special '
-                    '| augroup END'.format(col_before + 1))
-            else:
-                vim.command(
-                    'augroup jieba_vim_teardown_d_special '
-                    '| autocmd! '
-                    '| autocmd TextChanged <buffer> execute "normal! dd" '
-                    '| autocmd! jieba_vim_teardown_d_special '
-                    '| augroup END')
+        elif operator == 'd' and output.d_special:
+            vim.command('normal! "{}dd'.format(register))
+            # `reg_value2` consists of `chars_before_cursor` and the rest. We
+            # need this order: `chars_before_cursor`, `reg_value`, the rest.
+            reg_value2 = get_register_value(register)
+            reg_value = (
+                chars_before_cursor + reg_value + reg_value2[col_before:])
+            set_register_value(register, reg_value)
+            # We don't need this block because somehow having
+            # virtualedit=onemore overcomes the cursor position issue.
+            #if int(vim.eval('has("nvim")')):
+            #    vim.command("""execute 'silent call cursor(line("."), {})'"""
+            #                .format(col_before + 1))
+        vim.command('set virtualedit={}'.format(virtualedit_config))
 
     return {fun_name: _motion_wrapper}
 
@@ -211,7 +220,7 @@ def _vim_wrapper_factory_omap_b(motion_name):
     assert motion_name in ['b', 'B']
     fun_name = 'omap_' + motion_name
 
-    def _motion_wrapper(operator, count):
+    def _motion_wrapper(register, operator, count):
         count = upperbound_count(count)
         method = getattr(word_motion, fun_name)
         output = method(vim.current.buffer, vim.current.window.cursor, count)
@@ -221,8 +230,9 @@ def _vim_wrapper_factory_omap_b(motion_name):
             # `output.cursor[1] + 1` because vim column starts from 1 whereas
             # vim python api column starts from 0.
             vim.command(
-                'execute "silent normal! {}:call cursor({}, {})\\<CR>"'.format(
-                    operator, output.cursor[0], output.cursor[1] + 1))
+                '''execute 'silent normal! "{}{}:call cursor({}, {})' . "\\<CR>"'''
+                .format(register, operator, output.cursor[0],
+                        output.cursor[1] + 1))
             if operator == 'c':
                 # Running `c` in `normal!` as above will shift the cursor one more
                 # character to the left; so we need to shift back one character.
@@ -237,7 +247,7 @@ def _vim_wrapper_factory_omap_ge(motion_name):
     assert motion_name in ['ge', 'gE']
     fun_name = 'omap_' + motion_name
 
-    def _motion_wrapper(operator, count):
+    def _motion_wrapper(register, operator, count):
         count = upperbound_count(count)
         method = getattr(word_motion, fun_name)
         output = method(vim.current.buffer, vim.current.window.cursor,
@@ -249,8 +259,10 @@ def _vim_wrapper_factory_omap_ge(motion_name):
             # `output.cursor[1] + 1` because vim column starts from 1 whereas
             # vim python api column starts from 0.
             vim.command(
-                'execute "silent normal! {}v:call cursor({}, {})\\<CR>"'
-                .format(operator, output.cursor[0], output.cursor[1] + 1))
+                '''execute 'silent normal! "{}{}v:call cursor({}, {})' . "\\<CR>"'''
+                .format(register, operator, output.cursor[0],
+                        output.cursor[1] + 1))
+            reg_value = get_register_value(register)
             if operator == 'c':
                 # Running `c` in `normal!` as above will shift the cursor one
                 # more character to the left; so we need to shift back one
@@ -259,9 +271,10 @@ def _vim_wrapper_factory_omap_ge(motion_name):
                     vim.command('normal! l')
                 vim.command('startinsert')
             # This patch breaks `.` (see https://vimhelp.org/repeat.txt.html#.).
-            # Need help on fixing this issue.
             elif operator == 'd' and output.d_special:
-                vim.command('normal! dd')
+                vim.command('normal! "{}dd'.format(register))
+                reg_value += get_register_value(register)
+                set_register_value(register, reg_value)
                 if int(vim.eval('has("nvim")')):
                     vim.command(
                         '''execute "silent call cursor(line('.'), {})"'''

--- a/test/cases/issue_11_reg.vader.j2
+++ b/test/cases/issue_11_reg.vader.j2
@@ -1,0 +1,375 @@
+* This test checks the refactoring of motions w and b, plus the non-d-special
+* case of motions e and ge.
+
+{% set keys = ["w", "W", "e", "E", "b", "B", "ge", "gE"] -%}
+{%- set bang = "!" if verify else "" -%}
+{%- set vim_compatible = true -%}
+{%- set nvim_compatible = true %}
+
+Before:
+  {%- for k in keys %}
+  map {{ k }} <Plug>(Jieba_{{ k }})
+  {%- endfor %}
+  let @a = ""
+  let @" = ""
+
+After:
+  {%- for k in keys %}
+  unmap {{ k }}
+  {%- endfor %}
+
+---
+
+{%- if (not vim or vim_compatible) and (not nvim or nvim_compatible) %}
+
+Given:
+  aa bb ccc
+
+Execute (unnamed register for w, delete):
+  normal! gg0w
+  normal{{ bang }} dw
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  aa ccc
+
+Execute (unnamed register for w, delete + paste):
+  normal! gg0w
+  normal{{ bang }} dw
+  normal! P
+
+Then:
+  AssertEqual 6, col(".")
+
+Expect:
+  aa bb ccc
+
+Execute (unnamed register for w, change):
+  normal! gg0w
+  normal{{ bang }} cwXYZ
+
+Then:
+  AssertEqual 6, col(".")
+
+Expect:
+  aa XYZ ccc
+
+Execute (unnamed register for w, change + paste):
+  normal! gg0w
+  normal{{ bang }} cwXYZ
+  normal! p
+
+Then:
+  AssertEqual 8, col(".")
+
+Expect:
+  aa XYZbb ccc
+
+Execute (named register for w, delete):
+  normal! gg0w
+  normal{{ bang }} "adw
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  aa ccc
+
+Execute (named register for w, delete + paste):
+  normal! gg0w
+  normal{{ bang }} "adw
+  normal! "aP
+
+Then:
+  AssertEqual 6, col(".")
+
+Expect:
+  aa bb ccc
+
+Execute (named register for w, change):
+  normal! gg0w
+  normal{{ bang }} "acwXYZ
+
+Then:
+  AssertEqual 6, col(".")
+
+Expect:
+  aa XYZ ccc
+
+Execute (named register for w, change + paste):
+  normal! gg0w
+  normal{{ bang }} "acwXYZ
+  normal! "ap
+
+Then:
+  AssertEqual 8, col(".")
+
+Expect:
+  aa XYZbb ccc
+
+---
+
+Execute (unnamed register for b, delete):
+  normal! gg0w
+  normal{{ bang }} db
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  bb ccc
+
+Execute (unnamed register for b, delete + paste):
+  normal! gg0w
+  normal{{ bang }} db
+  normal! P
+
+Then:
+  AssertEqual 3, col(".")
+
+Expect:
+  aa bb ccc
+
+Execute (unnamed register for b, change):
+  normal! gg0w
+  normal{{ bang }} cbXYZ
+
+Then:
+  AssertEqual 3, col(".")
+
+Expect:
+  XYZbb ccc
+
+Execute (unnamed register for b, change + paste):
+  normal! gg0w
+  normal{{ bang }} cbXYZ
+  normal! p
+
+Then:
+  AssertEqual 6, col(".")
+
+Expect:
+  XYZaa bb ccc
+
+Execute (named register for b, delete):
+  normal! gg0w
+  normal{{ bang }} "adb
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  bb ccc
+
+Execute (named register for b, delete + paste):
+  normal! gg0w
+  normal{{ bang }} "adb
+  normal! "aP
+
+Then:
+  AssertEqual 3, col(".")
+
+Expect:
+  aa bb ccc
+
+Execute (named register for b, change):
+  normal! gg0w
+  normal{{ bang }} "acbXYZ
+
+Then:
+  AssertEqual 3, col(".")
+
+Expect:
+  XYZbb ccc
+
+Execute (named register for b, change + paste):
+  normal! gg0w
+  normal{{ bang }} "acbXYZ
+  normal! "ap
+
+Then:
+  AssertEqual 6, col(".")
+
+Expect:
+  XYZaa bb ccc
+
+---
+
+Execute (unnamed register for e, delete):
+  normal! gg0w
+  normal{{ bang }} de
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  aa  ccc
+
+Execute (unnamed register for e, delete + paste):
+  normal! gg0w
+  normal{{ bang }} de
+  normal! P
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  aa bb ccc
+
+Execute (unnamed register for e, change):
+  normal! gg0w
+  normal{{ bang }} ceXYZ
+
+Then:
+  AssertEqual 6, col(".")
+
+Expect:
+  aa XYZ ccc
+
+Execute (unnamed register for e, change + paste):
+  normal! gg0w
+  normal{{ bang }} ceXYZ
+  normal! p
+
+Then:
+  AssertEqual 8, col(".")
+
+Expect:
+  aa XYZbb ccc
+
+Execute (named register for e, delete):
+  normal! gg0w
+  normal{{ bang }} "ade
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  aa  ccc
+
+Execute (named register for e, delete + paste):
+  normal! gg0w
+  normal{{ bang }} "ade
+  normal! "aP
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  aa bb ccc
+
+Execute (named register for e, change):
+  normal! gg0w
+  normal{{ bang }} "aceXYZ
+
+Then:
+  AssertEqual 6, col(".")
+
+Expect:
+  aa XYZ ccc
+
+Execute (named register for e, change + paste):
+  normal! gg0w
+  normal{{ bang }} "aceXYZ
+  normal! "ap
+
+Then:
+  AssertEqual 8, col(".")
+
+Expect:
+  aa XYZbb ccc
+
+---
+
+Execute (unnamed register for ge, delete):
+  normal! gg0w
+  normal{{ bang }} dge
+
+Then:
+  AssertEqual 2, col(".")
+
+Expect:
+  ab ccc
+
+Execute (unnamed register for ge, delete + paste):
+  normal! gg0w
+  normal{{ bang }} dge
+  normal! P
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  aa bb ccc
+
+Execute (unnamed register for ge, change):
+  normal! gg0w
+  normal{{ bang }} cgeXYZ
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  aXYZb ccc
+
+Execute (unnamed register for ge, change + paste):
+  normal! gg0w
+  normal{{ bang }} cgeXYZ
+  normal! p
+
+Then:
+  AssertEqual 7, col(".")
+
+Expect:
+  aXYZa bb ccc
+
+Execute (named register for ge, delete):
+  normal! gg0w
+  normal{{ bang }} "adge
+
+Then:
+  AssertEqual 2, col(".")
+
+Expect:
+  ab ccc
+
+Execute (named register for ge, delete + paste):
+  normal! gg0w
+  normal{{ bang }} "adge
+  normal! "aP
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  aa bb ccc
+
+Execute (named register for ge, change):
+  normal! gg0w
+  normal{{ bang }} "acgeXYZ
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  aXYZb ccc
+
+Execute (named register for ge, change + paste):
+  normal! gg0w
+  normal{{ bang }} "acgeXYZ
+  normal! "ap
+
+Then:
+  AssertEqual 7, col(".")
+
+Expect:
+  aXYZa bb ccc
+
+{% endif %}
+
+---
+
+Before:
+After:

--- a/test/cases/issue_11_reg_d_special.vader.j2
+++ b/test/cases/issue_11_reg_d_special.vader.j2
@@ -1,0 +1,360 @@
+* See https://github.com/kkew3/jieba.vim/issues/11.
+
+{% set keys = ["w", "W", "e", "E", "b", "B", "ge", "gE"] -%}
+{%- set bang = "!" if verify else "" -%}
+{%- set vim_compatible = true -%}
+{%- set nvim_compatible = true %}
+
+Before:
+  {%- for k in keys %}
+  map {{ k }} <Plug>(Jieba_{{ k }})
+  {%- endfor %}
+  let @a = ""
+  let @" = ""
+
+After:
+  {%- for k in keys %}
+  unmap {{ k }}
+  {%- endfor %}
+
+---
+
+{%- if (not vim or vim_compatible) and (not nvim or nvim_compatible) %}
+
+Given (aa bb ccc):
+  aa
+  
+  bb
+  
+  ccc
+
+Execute (unnamed register for motion e, delete):
+  normal! 2gg0
+  normal{{ bang }} d2e
+
+Then:
+  AssertEqual 1, line(".")
+  AssertEqual 1, col(".")
+
+Expect:
+  aa
+
+Execute (unnamed register for motion e, delete + paste):
+  normal! 2gg0
+  normal{{ bang }} d2e
+  normal! p
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  
+  bb
+  
+  ccc
+
+Execute (named register for motion e, delete):
+  normal! 2gg0
+  normal{{ bang }} "ad2e
+
+Then:
+  AssertEqual 1, line("."), "line should be 1, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+
+Execute (named register for motion e, delete + paste):
+  normal! 2gg0
+  normal{{ bang }} "ad2e
+  normal! "ap
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  
+  bb
+  
+  ccc
+
+---
+
+Given (aa bb):
+  aa
+  
+  bb
+  
+
+Execute (unnamed register for motion ge, delete):
+  normal! G0
+  normal{{ bang }} d2ge
+
+Then:
+  AssertEqual 1, line("."), "line should be 1, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+
+Execute (unnamed register for motion ge, delete + paste):
+  normal! G0
+  normal{{ bang }} d2ge
+  normal! p
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  
+  bb
+  
+
+Execute (named register for motion ge, delete):
+  normal! G0
+  normal{{ bang }} "ad2ge
+
+Then:
+  AssertEqual 1, line("."), "line should be 1, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+
+Execute (named register for motion ge, delete + paste):
+  normal! G0
+  normal{{ bang }} "ad2ge
+  normal! "ap
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  
+  bb
+  
+
+---
+
+Given (aa bb ccc dd):
+  aa
+  
+  bb
+  
+  ccc
+  dd
+
+Execute (unnamed register for motion e, delete):
+  normal! 2gg0
+  normal{{ bang }} d2e
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  dd
+
+Execute (unnamed register for motion e, delete + paste):
+  normal! 2gg0
+  normal{{ bang }} d2e
+  normal! p
+
+Then:
+  AssertEqual 3, line("."), "line should be 3, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  dd
+  
+  bb
+  
+  ccc
+
+Execute (named register for motion e, delete):
+  normal! 2gg0
+  normal{{ bang }} "ad2e
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  dd
+
+Execute (named register for motion e, delete + paste):
+  normal! 2gg0
+  normal{{ bang }} "ad2e
+  normal! "ap
+
+Then:
+  AssertEqual 3, line("."), "line should be 3, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  dd
+  
+  bb
+  
+  ccc
+
+---
+
+Given (aa bb ccc):
+  aa
+  
+  bb
+  
+  ccc
+
+Execute (unnamed register for motion ge, delete):
+  normal! 4gg0
+  normal{{ bang }} d2ge
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  ccc
+
+Execute (unnamed register for motion ge, delete + paste):
+  normal! 4gg0
+  normal{{ bang }} d2ge
+  normal! p
+
+Then:
+  AssertEqual 3, line("."), "line should be 3, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  ccc
+  
+  bb
+  
+
+Execute (named register for motion ge, delete):
+  normal! 4gg0
+  normal{{ bang }} "ad2ge
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  ccc
+
+Execute (named register for motion ge, delete + paste):
+  normal! 4gg0
+  normal{{ bang }} "ad2ge
+  normal! "ap
+
+Then:
+  AssertEqual 3, line("."), "line should be 3, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  ccc
+  
+  bb
+  
+
+---
+
+Given (aa bb quote):
+  aa
+  
+  bb"
+  
+
+Execute (unnamed register for motion e, delete + paste):
+  normal! 2gg0
+  normal{{ bang }} d3e
+  normal! p
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  
+  bb"
+  
+
+Execute (unnamed register for motion ge, delete + paste):
+  normal! G0
+  normal{{ bang }} d3ge
+  normal! p
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  
+  bb"
+  
+
+---
+
+Given (text with backslash quote):
+  aa
+  
+  bb\"
+  
+
+Execute (unnamed register for motion e, delete + paste):
+  normal! 2gg0
+  normal{{ bang }} d3e
+  normal! p
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  
+  bb\"
+  
+
+Execute (unnamed register for motion ge, delete + paste):
+  normal! G0
+  normal{{ bang }} d3ge
+  normal! p
+
+Then:
+  AssertEqual 2, line("."), "line should be 2, but got " . line(".")
+  AssertEqual 1, col("."), "col should be 1, but got " . col(".")
+
+Expect:
+  aa
+  
+  bb\"
+  
+
+
+{% endif %}
+
+---
+
+Before:
+After:

--- a/test/cases/issue_11_reg_d_special_nvim.vader.j2
+++ b/test/cases/issue_11_reg_d_special_nvim.vader.j2
@@ -1,0 +1,101 @@
+* See https://github.com/kkew3/jieba.vim/issues/11.
+* This test contains some spacial case specific to neovim.
+
+{% set keys = ["w", "W", "e", "E", "b", "B", "ge", "gE"] -%}
+{%- set bang = "!" if verify else "" -%}
+{%- set vim_compatible = false -%}
+{%- set nvim_compatible = true %}
+
+Before:
+  {%- for k in keys %}
+  map {{ k }} <Plug>(Jieba_{{ k }})
+  {%- endfor %}
+  let @a = ""
+  let @" = ""
+
+After:
+  {%- for k in keys %}
+  unmap {{ k }}
+  {%- endfor %}
+
+---
+
+{%- if (not vim or vim_compatible) and (not nvim or nvim_compatible) %}
+
+Given (aa bb ccc):
+  aaaaaaaaaaaaaa
+         d
+  bb
+  
+  ccc
+
+Execute (unnamed register for motion e, delete):
+  normal! 2gg7l
+  normal{{ bang }} d2e
+
+Then:
+  AssertEqual 1, line(".")
+  AssertEqual 8, col(".")
+
+Expect:
+  aaaaaaaaaaaaaa
+
+Execute (unnamed register for motion e, delete + paste):
+  normal! 2gg7l
+  normal{{ bang }} d2e
+  normal! p
+
+Then:
+  AssertEqual 2, line(".")
+  AssertEqual 8, col(".")
+
+Expect:
+  aaaaaaaaaaaaaa
+         d
+  bb
+  
+  ccc
+
+---
+
+Given (aa bb ccc):
+  aa
+  
+  bb
+         
+  ccccccccccccc
+
+Execute (unnamed register for motion ge, delete):
+  normal! 4gg7l
+  normal{{ bang }} d2ge
+
+Then:
+  AssertEqual 2, line(".")
+  AssertEqual 7, col(".")
+
+Expect:
+  aa
+  ccccccccccccc
+
+Execute (unnamed register for motion ge, delete + paste):
+  normal! 4gg7l
+  normal{{ bang }} d2ge
+  normal! p
+
+Then:
+  AssertEqual 3, line(".")
+  AssertEqual 1, col(".")
+
+Expect:
+  aa
+  ccccccccccccc
+  
+  bb
+         
+
+{% endif %}
+
+---
+
+Before:
+After:

--- a/test/cases/issue_11_reg_d_special_vim.vader.j2
+++ b/test/cases/issue_11_reg_d_special_vim.vader.j2
@@ -1,0 +1,101 @@
+* See https://github.com/kkew3/jieba.vim/issues/11.
+* This test contains some spacial case specific to vim.
+
+{% set keys = ["w", "W", "e", "E", "b", "B", "ge", "gE"] -%}
+{%- set bang = "!" if verify else "" -%}
+{%- set vim_compatible = true -%}
+{%- set nvim_compatible = false %}
+
+Before:
+  {%- for k in keys %}
+  map {{ k }} <Plug>(Jieba_{{ k }})
+  {%- endfor %}
+  let @a = ""
+  let @" = ""
+
+After:
+  {%- for k in keys %}
+  unmap {{ k }}
+  {%- endfor %}
+
+---
+
+{%- if (not vim or vim_compatible) and (not nvim or nvim_compatible) %}
+
+Given (aa bb ccc):
+  aa
+         
+  bb
+  
+  ccc
+
+Execute (unnamed register for motion e, delete):
+  normal! 2gg$
+  normal{{ bang }} d2e
+
+Then:
+  AssertEqual 1, line(".")
+  AssertEqual 1, col(".")
+
+Expect:
+  aa
+
+Execute (unnamed register for motion e, delete + paste):
+  normal! 2gg$
+  normal{{ bang }} d2e
+  normal! p
+
+Then:
+  AssertEqual 2, line(".")
+  AssertEqual 7, col(".")
+
+Expect:
+  aa
+         
+  bb
+  
+  ccc
+
+---
+
+Given (aa bb ccc):
+  aa
+  
+  bb
+         
+  ccc
+
+Execute (unnamed register for motion ge, delete):
+  normal! 4gg$
+  normal{{ bang }} d2ge
+
+Then:
+  AssertEqual 2, line(".")
+  AssertEqual 1, col(".")
+
+Expect:
+  aa
+  ccc
+
+Execute (unnamed register for motion ge, delete + paste):
+  normal! 4gg$
+  normal{{ bang }} d2ge
+  normal! p
+
+Then:
+  AssertEqual 3, line(".")
+  AssertEqual 1, col(".")
+
+Expect:
+  aa
+  ccc
+  
+  bb
+         
+
+{% endif %}
+
+---
+
+Before:
+After:


### PR DESCRIPTION
This commit also drops dependency of all omap motions on side effects (i.e. one-off augroup trick used in https://github.com/svermeulen/vim-NotableFt), because in some vimscript environment, it becomes unreliable and might not be triggered as expected. As a result, the onoremap writing styles for all motions are unified.