### PR TITLE
Fix issue #6

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           ${{ matrix.vim.dist }} --version
 
-      - name: Install vader.vim
+      - name: Install vader.vim and vim-repeat
         if: steps.cache-vim.outputs.cache-hit != 'true'
         run: |
           mkdir "$GITHUB_WORKSPACE/vim_bundle"
@@ -135,6 +135,9 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE/jieba_vim/test"
           pip install .
+      
+      - name: Debug before running integration test
+        uses: fawazahmed0/action-debug-vscode@main
       
       - name: Run integration tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           path: |
             vim
-            vim_bundle/vader.vim
+            vim_bundle
           key: vim-distro-${{ matrix.vim.dist }}-${{ matrix.vim.version }}
 
       - name: Install vim/nvim
@@ -117,6 +117,7 @@ jobs:
         run: |
           mkdir "$GITHUB_WORKSPACE/vim_bundle"
           git clone https://github.com/junegunn/vader.vim.git "$GITHUB_WORKSPACE/vim_bundle/vader.vim"
+          git clone https://github.com/tpope/vim-repeat.git "$GITHUB_WORKSPACE/vim_bundle/vim-repeat"
 
       - name: Verify and run unit tests
         run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -136,9 +136,6 @@ jobs:
           cd "$GITHUB_WORKSPACE/jieba_vim/test"
           pip install .
       
-      - name: Debug before running integration test
-        uses: fawazahmed0/action-debug-vscode@main
-      
       - name: Run integration tests
         run: |
           cd "$GITHUB_WORKSPACE/jieba_vim/test"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ vim +"py3 print(sys.version)"
 
 1. 增强八个 Vim word motion，即 `b`、`B`、`ge`、`gE`、`w`、`W`、`e`、`E`，在 `nmap`, `xmap` 和 `omap` 下的功能，使其能用于中文分词（同时也保留其按空格分词的功能）。其行为与默认行为相似，例如 `w` 不会跳过中文标点而 `W` 会跳过中文标点等。
 2. 在无中文 ASCII 文档中与 Vim 原生 word motion 行为*完全兼容*。结合懒惰加载（见下文 `g:jieba_vim_lazy` 开关）可实现（在某些文档类型中）常开。
-3. 预览 word motion 的跳转位置。由于中文分词有时存在歧义，即使没有歧义也会有人类与 jieba 的对齐问题，因此有时中文 word motion 的跳转位置并不显然。这时用户可能想提前预览将要进行的跳转将会跳转到哪些位置。
+3. 如果安装了 [`tpope/vim-repeat`][vim-repeat]，可使用 [`.`][dot-repeat] 重复上一次 word operation。例如 `dw.` 相当于 `dwdw`。
+4. 预览 word motion 的跳转位置。由于中文分词有时存在歧义，即使没有歧义也会有人类与 jieba 的对齐问题，因此有时中文 word motion 的跳转位置并不显然。这时用户可能想提前预览将要进行的跳转将会跳转到哪些位置。
 
 ## 使用
 
@@ -127,7 +128,8 @@ vim +"py3 print(sys.version)"
 
 1. Augment eight Vim word motions (i.e. `b`, `B`, `ge`, `gE`, `w`, `W`, `e`, `E`) such that they can be used in Chinese text and English text at the same time. The augmented behavior remains similar. For example, augmented `w` won't jump over Chinese punctuation whereas `W` will.
 2. The behavior of the augmented word motions is compatible with Vim's original word motions when handling ASCII text without Chinese. Together with lazy loading (see the option `g:jieba_vim_lazy`), it's possible to leave this plugin on (for certain file types).
-3. Preview the destination of the word motions beforehand. Since there's sometimes ambiguity in Chinese word segmentation, and since even when there's no ambiguity, jieba library may not align well with human users, it's not always evident where a word motion will jump to. In such circumstance, user may want to preview jumps beforehand.
+3. If [`tpope/vim-repeat`][vim-repeat] has been installed, [`.`][dot-repeat] can be used to repeat last word operation. For example, `dw.` will be equivalent to `dwdw`.
+4. Preview the destination of the word motions beforehand. Since there's sometimes ambiguity in Chinese word segmentation, and since even when there's no ambiguity, jieba library may not align well with human users, it's not always evident where a word motion will jump to. In such circumstance, user may want to preview jumps beforehand.
 
 ## Usage
 
@@ -192,3 +194,5 @@ Apache license v2.
 [4]: https://github.com/ginqi7/deno-bridge-jieba
 [5]: https://github.com/cathaysia/jieba_nvim
 [6]: https://github.com/junegunn/vim-plug
+[vim-repeat]: https://github.com/tpope/vim-repeat
+[dot-repeat]: https://vimhelp.org/repeat.txt.html#.

--- a/doc/jieba.txt
+++ b/doc/jieba.txt
@@ -7,6 +7,7 @@ CONTENTS                                                      *jieba-contents*
   2. Configuration..............................................|jieba-config|
   3. Commands.................................................|jieba-commands|
   4. Mappings.................................................|jieba-mappings|
+  5. Optional Dependency................................|jieba-opt-dependency|
 
 ==============================================================================
 INTRODUCTION                                                     *jieba-intro*
@@ -51,6 +52,12 @@ MAPPINGS                                                      *jieba-mappings*
 <
 提供快捷开关 g:jieba_vim_keymap，可通过在 .vimrc 中将其设为 1 来开启对八个 word motion 的 nmap, xmap
 和 omap。
+
+==============================================================================
+OPTIONAL DEPENDENCY                                     *jieba-opt-dependency*
+
+如果用户安装了 `tpope/vim-repeat` (https://github.com/tpope/vim-repeat)，可使用 |.| 重复上一次
+word operation。例如 `dw.` 相当于 `dwdw`。
 
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -17,7 +17,7 @@
 " @section Introduction, intro
 " @stylized jieba.vim
 " @library
-" @order intro config
+" @order intro config commands mappings opt-dependency
 " jieba.vim 是一个基于 jieba 中文分词插件.
 
 
@@ -72,6 +72,11 @@ let s:motions = ["w", "W", "e", "E", "b", "B", "ge", "gE"]
 " 提供快捷开关 g:jieba_vim_keymap，可通过在 .vimrc 中将其设为 1 来开启对八个
 " word motion 的 nmap, xmap 和 omap。
 
+""
+" @section Optional Dependency, opt-dependency
+" 如果用户安装了 `tpope/vim-repeat` (https://github.com/tpope/vim-repeat)，可使用 |.|
+" 重复上一次 word operation。例如 `dw.` 相当于 `dwdw`。
+
 
 for ky in s:motions
     execute 'nnoremap <silent> <Plug>(Jieba_preview_' . ky . ') :<C-u>py3 jieba_vim.preview(jieba_vim.navigation.word_motion.preview_nmap_' . ky . ')<CR>'
@@ -80,6 +85,18 @@ nnoremap <silent> <Plug>(Jieba_preview_cancel) :<C-u>py3 jieba_vim.preview_cance
 
 for ky in s:motions
     execute 'nnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') ":<C-u>py3 jieba_vim.navigation.nmap_' . ky . '(" . v:count1 . ")<CR>"'
+    " This mapping is used internally to implement dot-repeat.
+    execute
+        \ 'nnoremap <expr> <silent> <Plug>(Jieba_internal_o_'
+        \ . ky
+        \ . ') "<Esc>:<C-u>py3 jieba_vim.navigation.omap_'
+        \ . ky
+        \ . "('"
+        \ . '" . v:register . "'
+        \ . "', '"
+        \ . '" . v:operator . "'
+        \ . "', "
+        \ . '" . v:count1 . ")<CR>"'
     execute
         \ 'onoremap <expr> <silent> <Plug>(Jieba_'
         \ . ky

--- a/pythonx/jieba_vim/navigation.py
+++ b/pythonx/jieba_vim/navigation.py
@@ -145,6 +145,9 @@ def _vim_wrapper_factory_omap_w(motion_name):
     fun_name = 'omap_' + motion_name
 
     def _motion_wrapper(register, operator, count):
+        vim.command(
+            'silent! call repeat#setreg("\\<Plug>(Jieba_internal_o_{})", \'{}\')'
+            .format(motion_name, register))
         count = upperbound_count(count)
         method = getattr(word_motion, fun_name)
         virtualedit_config = vim.eval('&virtualedit')
@@ -165,6 +168,9 @@ def _vim_wrapper_factory_omap_w(motion_name):
                 vim.command('normal! l')
             vim.command('startinsert')
         vim.command('set virtualedit={}'.format(virtualedit_config))
+        vim.command(
+            'silent! call repeat#set("\\<Plug>(Jieba_internal_o_{})", {})'
+            .format(motion_name, count))
 
     return {fun_name: _motion_wrapper}
 
@@ -174,6 +180,9 @@ def _vim_wrapper_factory_omap_e(motion_name):
     fun_name = 'omap_' + motion_name
 
     def _motion_wrapper(register, operator, count):
+        vim.command(
+            'silent! call repeat#setreg("\\<Plug>(Jieba_internal_o_{})", \'{}\')'
+            .format(motion_name, register))
         count = upperbound_count(count)
         method = getattr(word_motion, fun_name)
         virtualedit_config = vim.eval('&virtualedit')
@@ -197,7 +206,6 @@ def _vim_wrapper_factory_omap_e(motion_name):
             if col_before:
                 vim.command('normal! l')
             vim.command('startinsert')
-        # This patch breaks `.` (see https://vimhelp.org/repeat.txt.html#.).
         elif operator == 'd' and output.d_special:
             vim.command('normal! "{}dd'.format(register))
             # `reg_value2` consists of `chars_before_cursor` and the rest. We
@@ -212,6 +220,9 @@ def _vim_wrapper_factory_omap_e(motion_name):
             #    vim.command("""execute 'silent call cursor(line("."), {})'"""
             #                .format(col_before + 1))
         vim.command('set virtualedit={}'.format(virtualedit_config))
+        vim.command(
+            'silent! call repeat#set("\\<Plug>(Jieba_internal_o_{})", {})'
+            .format(motion_name, count))
 
     return {fun_name: _motion_wrapper}
 
@@ -221,6 +232,9 @@ def _vim_wrapper_factory_omap_b(motion_name):
     fun_name = 'omap_' + motion_name
 
     def _motion_wrapper(register, operator, count):
+        vim.command(
+            'silent! call repeat#setreg("\\<Plug>(Jieba_internal_o_{})", \'{}\')'
+            .format(motion_name, register))
         count = upperbound_count(count)
         method = getattr(word_motion, fun_name)
         output = method(vim.current.buffer, vim.current.window.cursor, count)
@@ -239,6 +253,9 @@ def _vim_wrapper_factory_omap_b(motion_name):
                 if output.cursor[1] > 0:
                     vim.command('normal! l')
                 vim.command('startinsert')
+        vim.command(
+            'silent! call repeat#set("\\<Plug>(Jieba_internal_o_{})", {})'
+            .format(motion_name, count))
 
     return {fun_name: _motion_wrapper}
 
@@ -248,6 +265,9 @@ def _vim_wrapper_factory_omap_ge(motion_name):
     fun_name = 'omap_' + motion_name
 
     def _motion_wrapper(register, operator, count):
+        vim.command(
+            'silent! call repeat#setreg("\\<Plug>(Jieba_internal_o_{})", \'{}\')'
+            .format(motion_name, register))
         count = upperbound_count(count)
         method = getattr(word_motion, fun_name)
         output = method(vim.current.buffer, vim.current.window.cursor,
@@ -270,7 +290,6 @@ def _vim_wrapper_factory_omap_ge(motion_name):
                 if output.cursor[1] > 0:
                     vim.command('normal! l')
                 vim.command('startinsert')
-            # This patch breaks `.` (see https://vimhelp.org/repeat.txt.html#.).
             elif operator == 'd' and output.d_special:
                 vim.command('normal! "{}dd'.format(register))
                 reg_value += get_register_value(register)
@@ -279,6 +298,9 @@ def _vim_wrapper_factory_omap_ge(motion_name):
                     vim.command(
                         '''execute "silent call cursor(line('.'), {})"'''
                         .format(col_before + 1))
+        vim.command(
+            'silent! call repeat#set("\\<Plug>(Jieba_internal_o_{})", {})'
+            .format(motion_name, count))
 
     return {fun_name: _motion_wrapper}
 

--- a/pythonx/jieba_vim_rs_core/Cargo.toml
+++ b/pythonx/jieba_vim_rs_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jieba_vim_rs_core"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [dependencies]

--- a/pythonx/jieba_vim_rs_core/src/token.rs
+++ b/pythonx/jieba_vim_rs_core/src/token.rs
@@ -695,6 +695,19 @@ fn cut_hanzi_rule<C: JiebaPlaceholder>(
             // We have assumed that each subgroup contains chars of the same
             // major class, which is subject to the property of `jieba`.
             let sub_groups = group.split_into_subgroups(n_chars);
+            // In the case where `group` is the first group, it's likely
+            // that the first sub-group is a combining diacritical mark, and
+            // we need to convert it again to a word. This happens because
+            // `split_into_subgroups` recategorizes chars.
+            let sub_groups = if prev_group.is_none() {
+                utils::stack_merge(
+                    sub_groups,
+                    &(),
+                    convert_first_cdm_group_rule,
+                )
+            } else {
+                sub_groups
+            };
             utils::chain_into_vec(
                 prev_group,
                 utils::stack_merge(
@@ -1064,6 +1077,20 @@ mod tests {
                 assert!(tok.col.incl_end_byte_index < tok.col.excl_end_byte_index);
                 start = tok.col.excl_end_byte_index;
             }
+        }
+    }
+
+    #[test]
+    fn test_dba879258_parse_str_tokens_are_nonempty_contiguous_word() {
+        let s = "\u{300}A⼀";
+        let tokens = parse_str_test(s, true);
+        let mut start = 0;
+        for tok in tokens {
+            assert_eq!(tok.col.start_byte_index, start);
+            assert!(tok.col.start_byte_index < tok.col.excl_end_byte_index);
+            assert!(tok.col.start_byte_index <= tok.col.incl_end_byte_index);
+            assert!(tok.col.incl_end_byte_index < tok.col.excl_end_byte_index);
+            start = tok.col.excl_end_byte_index;
         }
     }
 

--- a/test/cases/issue_6_repeat.vader.j2
+++ b/test/cases/issue_6_repeat.vader.j2
@@ -1,0 +1,602 @@
+* See https://github.com/kkew3/jieba.vim/issues/6.
+
+{% set keys = ["w", "W", "e", "E", "b", "B", "ge", "gE"] -%}
+{%- set bang = "!" if verify else "" -%}
+{%- set vim_compatible = true -%}
+{%- set nvim_compatible = true %}
+
+Before:
+  {%- for k in keys %}
+  map {{ k }} <Plug>(Jieba_{{ k }})
+  {%- endfor %}
+  let @a = ""
+  let @" = ""
+
+After:
+  {%- for k in keys %}
+  unmap {{ k }}
+  {%- endfor %}
+
+---
+
+{%- if (not vim or vim_compatible) and (not nvim or nvim_compatible) %}
+
+* These are the cases on the issue page.
+
+Given:
+  a
+     
+  b
+     
+  cd
+
+Execute (case 1 first step):
+  normal! 4gg0
+  normal{{ bang }} dge
+
+Then:
+  AssertEqual 3, line(".")
+  AssertEqual 1, col(".")
+
+Expect:
+  a
+     
+  cd
+
+Execute (case 1 first step + repeat):
+  normal! 4gg0
+  normal{{ bang }} dge
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, line(".")
+  AssertEqual 1, col(".")
+
+Expect:
+  d
+
+Execute (case 2 first step):
+  normal! 5gg0
+  normal{{ bang }} dge
+
+Then:
+  AssertEqual 3, line(".")
+  AssertEqual 1, col(".")
+
+Expect:
+  a
+     
+  d
+
+Execute (case 2 first step + repeat):
+  normal! 5gg0
+  normal{{ bang }} dge
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, line(".")
+  AssertEqual 1, col(".")
+
+Expect:
+  
+
+Given:
+  abc def ghi
+
+Execute (case 3 first step):
+  normal! $
+  normal{{ bang }} db
+
+Then:
+  AssertEqual 9, col(".")
+
+Expect:
+  abc def i
+
+Execute (case 3 first step + repeat):
+  normal! $
+  normal{{ bang }} db
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc i
+
+
+
+* Below are more systematic tests.
+
+* Simple one line cases.
+
+Given:
+  abc defg gh ijkl mn opq
+
+Execute (dw first step):
+  normal! fd
+  normal{{ bang }} dw
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc gh ijkl mn opq
+
+Execute (dw first step + repeat x1):
+  normal! fd
+  normal{{ bang }} dw
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc ijkl mn opq
+
+Execute (dw first step + repeat x2):
+  normal! fd
+  normal{{ bang }} dw
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc mn opq
+
+Execute (dw first step + repeat x4):
+  normal! fd
+  normal{{ bang }} dw
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  abc 
+
+Execute (dw first step + repeat x5):
+  normal! fd
+  normal{{ bang }} dw
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 3, col(".")
+
+Expect:
+  abc
+
+Execute (dw first step + repeat x6):
+  normal! fd
+  normal{{ bang }} dw
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 2, col(".")
+
+Expect:
+  ab
+
+Execute (dw first step + repeat x8):
+  normal! fd
+  normal{{ bang }} dw
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  
+
+Execute (dw first step + repeat x9):
+  normal! fd
+  normal{{ bang }} dw
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  
+
+Execute (d2w first step):
+  normal! fd
+  normal{{ bang }} d2w
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc ijkl mn opq
+
+Execute (d2w first step + repeat x1):
+  normal! fd
+  normal{{ bang }} d2w
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc opq
+
+---
+
+Given:
+  abc defg gh ijkl mn opq
+
+Execute (de first step):
+  normal! fd
+  normal{{ bang }} de
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc  gh ijkl mn opq
+
+Execute (de first step + repeat x1):
+  normal! fd
+  normal{{ bang }} de
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc  ijkl mn opq
+
+Execute (de first step + repeat x2):
+  normal! fd
+  normal{{ bang }} de
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc  mn opq
+
+Execute (de first step + repeat x4):
+  normal! fd
+  normal{{ bang }} de
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 4, col(".")
+
+Expect:
+  abc 
+
+Execute (de first step + repeat x5):
+  normal! fd
+  normal{{ bang }} de
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 3, col(".")
+
+Expect:
+  abc
+
+Execute (de first step + repeat x6):
+  normal! fd
+  normal{{ bang }} de
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 2, col(".")
+
+Expect:
+  ab
+
+Execute (de first step + repeat x8):
+  normal! fd
+  normal{{ bang }} de
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  
+
+Execute (de first step + repeat x9):
+  normal! fd
+  normal{{ bang }} de
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  
+
+Execute (d2e first step):
+  normal! fd
+  normal{{ bang }} d2e
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc  ijkl mn opq
+
+Execute (d2e first step + repeat x1):
+  normal! fd
+  normal{{ bang }} d2e
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc  opq
+
+---
+
+Given:
+  abc defg gh ijkl mn opq
+
+Execute (db first step):
+  normal! fm
+  normal{{ bang }} db
+
+Then:
+  AssertEqual 13, col(".")
+
+Expect:
+  abc defg gh mn opq
+
+Execute (db first step + repeat x1):
+  normal! fm
+  normal{{ bang }} db
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 10, col(".")
+
+Expect:
+  abc defg mn opq
+
+Execute (db first step + repeat x2):
+  normal! fm
+  normal{{ bang }} db
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 5, col(".")
+
+Expect:
+  abc mn opq
+
+Execute (db first step + repeat x3):
+  normal! fm
+  normal{{ bang }} db
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  mn opq
+
+Execute (db first step + repeat x4):
+  normal! fm
+  normal{{ bang }} db
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  mn opq
+
+Execute (d2b first step):
+  normal! fm
+  normal{{ bang }} d2b
+
+Then:
+  AssertEqual 10, col(".")
+
+Expect:
+  abc defg mn opq
+
+Execute (d2b first step + repeat x1):
+  normal! fm
+  normal{{ bang }} d2b
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  mn opq
+
+---
+
+Given:
+  abc defg gh ijkl mn opq
+
+Execute (dge first step):
+  normal! fm
+  normal{{ bang }} dge
+
+Then:
+  AssertEqual 16, col(".")
+
+Expect:
+  abc defg gh ijkn opq
+
+Execute (dge first step + repeat x1):
+  normal! fm
+  normal{{ bang }} dge
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 11, col(".")
+
+Expect:
+  abc defg g opq
+
+Execute (dge first step + repeat x2):
+  normal! fm
+  normal{{ bang }} dge
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 10, col(".")
+
+Expect:
+  abc defg opq
+
+Execute (dge first step + repeat x3):
+  normal! fm
+  normal{{ bang }} dge
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 8, col(".")
+
+Expect:
+  abc defpq
+
+Execute (dge first step + repeat x4):
+  normal! fm
+  normal{{ bang }} dge
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 3, col(".")
+
+Expect:
+  abq
+
+Execute (dge first step + repeat x5):
+  normal! fm
+  normal{{ bang }} dge
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  
+
+Execute (dge first step + repeat x6):
+  normal! fm
+  normal{{ bang }} dge
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 1, col(".")
+
+Expect:
+  
+
+Execute (d2ge first step):
+  normal! fm
+  normal{{ bang }} d2ge
+
+Then:
+  AssertEqual 11, col(".")
+
+Expect:
+  abc defg gn opq
+
+Execute (d2ge first step + repeat x1):
+  normal! fm
+  normal{{ bang }} d2ge
+  normal{{ bang }} .
+
+Then:
+  AssertEqual 3, col(".")
+
+Expect:
+  ab opq
+
+
+{% endif %}
+
+---
+
+Before:
+After:

--- a/test/vimrc
+++ b/test/vimrc
@@ -3,8 +3,10 @@ set nocompatible
 if exists("$VIM_BUNDLE_PATH")
     " For Github workflows.
     let &rtp .= "," . expand("$VIM_BUNDLE_PATH") . "/vader.vim"
+    let &rtp .= "," . expand("$VIM_BUNDLE_PATH") . "/vim-repeat"
 else
     set rtp+=~/.vim/bundle/vader.vim
+    set rtp+=~/.vim/bundle/vim-repeat
 endif
 set rtp+=..
 filetype plugin indent on


### PR DESCRIPTION
This commit adds support to dot-repeat (https://vimhelp.org/repeat.txt.html#.) of the word motions based on tpope/vim-repeat (https://github.com/tpope/vim-repeat.git), backed by integration tests. So issue #5 is also resolved. The README and the documentation have been updated.