### PR TITLE
Add `'isk'` parser from scratch rather than relying on CFG grammar

### DIFF
--- a/rust_backend/Cargo.lock
+++ b/rust_backend/Cargo.lock
@@ -309,13 +309,12 @@ dependencies = [
 
 [[package]]
 name = "jieba_vim_rs_core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "jieba_vim_rs_test",
  "jieba_vim_rs_test_macro",
  "once_cell",
  "proptest",
- "santiago",
  "trie-rs",
  "unic-emoji-char",
 ]
@@ -743,15 +742,6 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
-]
-
-[[package]]
-name = "santiago"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de36022292bc2086eb8f55bffa460fef3475e4459b478820711f4c421feb87ec"
-dependencies = [
- "regex",
 ]
 
 [[package]]

--- a/rust_backend/jieba_vim_rs_core/Cargo.toml
+++ b/rust_backend/jieba_vim_rs_core/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "jieba_vim_rs_core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 
 [dependencies]
 unic-emoji-char = "0.9"
-santiago = "1.3"
 
 [dev-dependencies]
 proptest = "1.9"

--- a/rust_backend/jieba_vim_rs_core/src/token/char.rs
+++ b/rust_backend/jieba_vim_rs_core/src/token/char.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Kaiwen Wu. All Rights Reserved.
+// Copyright 2025-2026 Kaiwen Wu. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -185,6 +185,8 @@ pub fn categorize_char(c: char, word_predicate: &WordPredicate) -> CharType {
         COMBINING_DIACRITICAL_MARK!() => CharType::CombiningDiacriticalMark,
         c => match super::ascii_or(c) {
             Some(ascii) => {
+                dbg!(ascii, word_predicate.is_ascii_word(ascii));
+                dbg!(word_predicate);
                 if word_predicate.is_ascii_word(ascii) {
                     CharType::Word(WordCharType::Other)
                 } else {
@@ -224,16 +226,14 @@ pub fn categorize_char(c: char, word_predicate: &WordPredicate) -> CharType {
 
 #[cfg(test)]
 mod tests {
-    use crate::token::isk::{IskParser, WordPredicate};
+    use crate::token::isk::WordPredicate;
 
     use super::{CharType, NonWordCharType, WordCharType, categorize_char};
 
     #[test]
     fn test_categorize_char() {
-        let isk_parser = IskParser::new();
-
         // Empty iskeyword.
-        let wp = WordPredicate::try_from_isk(&isk_parser, "").unwrap();
+        let wp = WordPredicate::from_isk_opt("").unwrap();
         assert!(matches!(
             categorize_char('a', &wp),
             CharType::NonWord(NonWordCharType::Other)
@@ -284,7 +284,7 @@ mod tests {
         ));
 
         // Lowercase ASCII iskeyword.
-        let wp = WordPredicate::try_from_isk(&isk_parser, "a-z").unwrap();
+        let wp = WordPredicate::from_isk_opt("a-z").unwrap();
         assert!(matches!(
             categorize_char('a', &wp),
             CharType::Word(WordCharType::Other)
@@ -335,8 +335,7 @@ mod tests {
         ));
 
         // Lowercase ASCII, digits and 汉字 iskeyword.
-        let wp =
-            WordPredicate::try_from_isk(&isk_parser, "@,^A-Z,48-57").unwrap();
+        let wp = WordPredicate::from_isk_opt("@,^A-Z,48-57").unwrap();
         assert!(matches!(
             categorize_char('a', &wp),
             CharType::Word(WordCharType::Other)
@@ -387,7 +386,7 @@ mod tests {
         ));
 
         // Digits and '>' iskeyword.
-        let wp = WordPredicate::try_from_isk(&isk_parser, "48-57,>").unwrap();
+        let wp = WordPredicate::from_isk_opt("48-57,>").unwrap();
         assert!(matches!(
             categorize_char('a', &wp),
             CharType::NonWord(NonWordCharType::Other)

--- a/rust_backend/jieba_vim_rs_core/src/token/isk.rs
+++ b/rust_backend/jieba_vim_rs_core/src/token/isk.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Kaiwen Wu. All Rights Reserved.
+// Copyright 2025-2026 Kaiwen Wu. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not
 // use this file except in compliance with the License. You may obtain a copy
@@ -13,561 +13,205 @@
 // under the License.
 
 //! Figure out which letters are words, based on `'iskeyword'` Vim option.
-//! Why to use context-free grammar parser when the option value is regular?
-//! Because it's not possible to capture repetition of the same group, while at
-//! the same time, iterative partial matching produces ambiguity.
 
-use std::rc::Rc;
-
-use santiago::grammar::Grammar;
-use santiago::lexer::{Lexeme, Lexer, LexerError, LexerRules, NextLexeme};
-use santiago::parser::ParseError;
-
-santiago::def!(NUMBER, "[0-9]+");
-santiago::def!(SINGLE_CHAR_NO_CARET, r"[ -/:-\]_-~]");
-santiago::def!(SINGLE_CHAR, "[ -/:-~]");
-
-fn push_and_take<'a>(lexer: &mut Lexer<'a>, state: &'a str) -> NextLexeme {
-    lexer.push_state(state);
-    lexer.take()
-}
-
-fn pop_and_take(lexer: &mut Lexer<'_>) -> NextLexeme {
-    lexer.pop_state();
-    lexer.take()
-}
-
-fn pop_and_skip(lexer: &mut Lexer<'_>) -> NextLexeme {
-    lexer.pop_state();
-    lexer.skip()
-}
-
-fn pop_push_and_take<'a>(lexer: &mut Lexer<'a>, state: &'a str) -> NextLexeme {
-    lexer.pop_state();
-    lexer.push_state(state);
-    lexer.take()
-}
-
-fn lexer_rules() -> LexerRules {
-    santiago::lexer_rules!(
-        "DEFAULT" | "NUMBER" = pattern NUMBER!() =>
-            |lexer| push_and_take(lexer, "ITEM_CHARSPEC");
-        "DEFAULT" | "SINGLE_CHAR_NO_CARET" = pattern SINGLE_CHAR_NO_CARET!() =>
-            |lexer| push_and_take(lexer, "ITEM_CHARSPEC");
-        "ITEM_CHARSPEC" | "PART_SEP" = string "," =>
-            pop_and_take;
-        "ITEM_CHARSPEC" | "" = string "" =>
-            pop_and_skip;
-        "ITEM_CHARSPEC" | "RANGE_SEP" = string "-" =>
-            |lexer| pop_push_and_take(lexer, "ITEM_RANGE");
-        "ITEM_RANGE" | "NUMBER" = pattern NUMBER!() =>
-            |lexer| pop_push_and_take(lexer, "ITEM_CHARSPEC_RHS");
-        "ITEM_RANGE" | "SINGLE_CHAR" = pattern SINGLE_CHAR!() =>
-            |lexer| pop_push_and_take(lexer, "ITEM_CHARSPEC_RHS");
-        "ITEM_CHARSPEC_RHS" | "PART_SEP" = string "," =>
-            pop_and_take;
-        "ITEM_CHARSPEC_RHS" | "" = string "" =>
-            pop_and_skip;
-        "DEFAULT" | "CARET" = string "^" =>
-            |lexer| push_and_take(lexer, "ITEM_CHARSPEC_CARET");
-        "ITEM_CHARSPEC_CARET" | "NUMBER" = pattern NUMBER!() =>
-            |lexer| pop_push_and_take(lexer, "NEG_ITEM_CHARSPEC");
-        "ITEM_CHARSPEC_CARET" | "SINGLE_CHAR" = pattern SINGLE_CHAR!() =>
-            |lexer| pop_push_and_take(lexer, "NEG_ITEM_CHARSPEC");
-        "ITEM_CHARSPEC_CARET"  | "" = string "" =>
-            pop_and_skip;
-        "NEG_ITEM_CHARSPEC" | "PART_SEP" = string "," =>
-            pop_and_take;
-        "NEG_ITEM_CHARSPEC" | "" = string "" =>
-            pop_and_skip;
-        "NEG_ITEM_CHARSPEC" | "RANGE_SEP" = string "-" =>
-            |lexer| pop_push_and_take(lexer, "NEG_ITEM_RANGE");
-        "NEG_ITEM_RANGE" | "NUMBER" = pattern NUMBER!() =>
-            |lexer| pop_push_and_take(lexer, "NEG_ITEM_CHARSPEC_RHS");
-        "NEG_ITEM_RANGE" | "SINGLE_CHAR" = pattern SINGLE_CHAR!() =>
-            |lexer| pop_push_and_take(lexer, "NEG_ITEM_CHARSPEC_RHS");
-        "NEG_ITEM_CHARSPEC_RHS" | "PART_SEP" = string "," =>
-            pop_and_take;
-        "NEG_ITEM_CHARSPEC_RHS" | "" = string "" =>
-            pop_and_skip;
-    )
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum CharSpec {
-    Number(u8),
-    Char(char),
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum Item {
-    CharSpec(CharSpec),
-    Range(CharSpec, CharSpec),
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum Part {
-    Part(Item),
-    NegPart(Item),
-}
-
-enum Ast {
-    PartSep,
-    RangeSep,
-    Number(u8),
-    SingleChar(char),
-    Parts { parts: Box<Ast>, part: Part },
-    PartsTerm,
-    Part(Item),
-    NegPart(Item),
-    CharSpecItem(CharSpec),
-    RangeItem(CharSpec, CharSpec),
-}
-
-fn vec_to_tuple1<T>(mut v: Vec<T>) -> T {
-    assert_eq!(v.len(), 1);
-    v.pop().unwrap()
-}
-
-fn vec_to_tuple2<T>(mut v: Vec<T>) -> (T, T) {
-    assert_eq!(v.len(), 2);
-    let b = v.pop().unwrap();
-    let a = v.pop().unwrap();
-    (a, b)
-}
-
-fn vec_to_tuple3<T>(mut v: Vec<T>) -> (T, T, T) {
-    assert_eq!(v.len(), 3);
-    let c = v.pop().unwrap();
-    let b = v.pop().unwrap();
-    let a = v.pop().unwrap();
-    (a, b, c)
-}
-
-fn ast_char_spec_to_char_spec(char_spec: Ast) -> CharSpec {
-    match char_spec {
-        Ast::Number(value) => CharSpec::Number(value),
-        Ast::SingleChar(value) => CharSpec::Char(value),
-        _ => unreachable!(),
-    }
-}
-
-fn ast_item_to_item(item: Ast) -> Item {
-    match item {
-        Ast::CharSpecItem(char_spec) => Item::CharSpec(char_spec),
-        Ast::RangeItem(lhs, rhs) => Item::Range(lhs, rhs),
-        _ => unreachable!(),
-    }
-}
-
-fn ast_part_to_part(part: Ast) -> Part {
-    match part {
-        Ast::Part(item) => Part::Part(item),
-        Ast::NegPart(neg_item) => Part::NegPart(neg_item),
-        _ => unreachable!(),
-    }
-}
-
-fn parse_lexemes_number(lexemes: &[&Rc<Lexeme>]) -> Ast {
-    let value = lexemes[0].raw.parse().unwrap();
-    Ast::Number(value)
-}
-
-fn parse_lexemes_single_char(lexemes: &[&Rc<Lexeme>]) -> Ast {
-    Ast::SingleChar(lexemes[0].raw.chars().next().unwrap())
-}
-
-fn grammar() -> Grammar<Ast> {
-    santiago::grammar!(
-        "sent" => empty =>
-            |_| Ast::PartsTerm;
-        "sent" => rules "parts" "last_part" =>
-            |trees| {
-                let (parts, last_part) = vec_to_tuple2(trees);
-                Ast::Parts {
-                    parts: Box::new(parts),
-                    part: ast_part_to_part(last_part),
-                }
-            };
-        "parts" => empty =>
-            |_| Ast::PartsTerm;
-        "parts" => rules "parts" "part" "part_sep" =>
-            |trees| {
-                let (parts, part, _) = vec_to_tuple3(trees);
-                Ast::Parts {
-                    parts: Box::new(parts),
-                    part: ast_part_to_part(part),
-                }
-            };
-        "part" => rules "item" =>
-            |trees| {
-                let item = vec_to_tuple1(trees);
-                Ast::Part(ast_item_to_item(item))
-            };
-        "part" => rules "caret" "neg_item" =>
-            |trees| {
-                let (_, neg_item) = vec_to_tuple2(trees);
-                Ast::NegPart(ast_item_to_item(neg_item))
-            };
-        "item" => rules "char_spec" =>
-            |trees| {
-                let char_spec = vec_to_tuple1(trees);
-                Ast::CharSpecItem(ast_char_spec_to_char_spec(char_spec))
-            };
-        "item" => rules "range" =>
-            vec_to_tuple1;
-        // "char_spec" => rules "number";
-        "char_spec" => lexemes "NUMBER" =>
-            parse_lexemes_number;
-        // "char_spec" => rules "single_char_no_caret";
-        "char_spec" => lexemes "SINGLE_CHAR_NO_CARET" =>
-            parse_lexemes_single_char;
-        "range" => rules "char_spec" "range_sep" "char_spec_rhs" =>
-            |trees| {
-                let (lhs, _, rhs) = vec_to_tuple3(trees);
-                let lhs = ast_char_spec_to_char_spec(lhs);
-                let rhs = ast_char_spec_to_char_spec(rhs);
-                Ast::RangeItem(lhs, rhs)
-            };
-        // "char_spec_rhs" => rules "number";
-        "char_spec_rhs" => lexemes "NUMBER" =>
-            parse_lexemes_number;
-        // "char_spec_rhs" => rules "single_char";
-        "char_spec_rhs" => lexemes "SINGLE_CHAR" =>
-            parse_lexemes_single_char;
-        // "char_spec_rhs" => rules "single_char_no_caret";
-        "char_spec_rhs" => lexemes "SINGLE_CHAR_NO_CARET" =>
-            parse_lexemes_single_char;
-        // "char_spec_rhs" => rules "caret";
-        "char_spec_rhs" => lexemes "CARET" =>
-            |_| Ast::SingleChar('^');
-        "neg_item" => rules "char_spec_rhs" =>
-            |trees| {
-                let char_spec = vec_to_tuple1(trees);
-                Ast::CharSpecItem(ast_char_spec_to_char_spec(char_spec))
-            };
-        "neg_item" => rules "neg_range" =>
-            vec_to_tuple1;
-        "neg_range" => rules "char_spec_rhs" "range_sep" "char_spec_rhs" =>
-            |trees| {
-                let (lhs, _, rhs) = vec_to_tuple3(trees);
-                let lhs = ast_char_spec_to_char_spec(lhs);
-                let rhs = ast_char_spec_to_char_spec(rhs);
-                Ast::RangeItem(lhs, rhs)
-            };
-        "last_part" => rules "last_item" =>
-            |trees| {
-                let item = vec_to_tuple1(trees);
-                Ast::Part(ast_item_to_item(item))
-            };
-        "last_part" => rules "caret" "neg_item" =>
-            |trees| {
-                let (_, neg_item) = vec_to_tuple2(trees);
-                Ast::NegPart(ast_item_to_item(neg_item))
-            };
-        "last_item" => rules "char_spec_rhs" =>
-            |trees| {
-                let char_spec = vec_to_tuple1(trees);
-                Ast::CharSpecItem(ast_char_spec_to_char_spec(char_spec))
-            };
-        "last_item" => rules "range" =>
-            vec_to_tuple1;
-
-        "part_sep" => lexemes "PART_SEP" =>
-            |_| Ast::PartSep;
-        "range_sep" => lexemes "RANGE_SEP" =>
-            |_| Ast::RangeSep;
-        "number" => lexemes "NUMBER" =>
-            parse_lexemes_number;
-        "caret" => lexemes "CARET" =>
-            |_| Ast::SingleChar('^');
-        "single_char_no_caret" => lexemes "SINGLE_CHAR_NO_CARET" =>
-            parse_lexemes_single_char;
-        "single_char" => lexemes "SINGLE_CHAR" =>
-            parse_lexemes_single_char;
-    )
-}
-
-/// `'iskeyword'` option parsing error.
-#[derive(Debug)]
-pub enum Error {
-    Lexer,
-    Parser,
-}
-
-impl From<LexerError> for Error {
-    fn from(_: LexerError) -> Self {
-        Error::Lexer
-    }
-}
-
-impl From<ParseError<Ast>> for Error {
-    fn from(_: ParseError<Ast>) -> Self {
-        Error::Parser
-    }
-}
-
-fn ast_parts_to_parts(parts: Ast) -> Vec<Part> {
-    let mut parts = parts;
-    let mut part_vec = Vec::new();
-    while let Ast::Parts { parts: inner, part } = parts {
-        part_vec.push(part);
-        parts = *inner;
-    }
-    part_vec.reverse();
-    part_vec
-}
-
-/// Parser for `'iskeyword'` option values.
-pub struct IskParser {
-    lexer_rules: LexerRules,
-    grammar: Grammar<Ast>,
-}
-
-impl IskParser {
-    pub fn new() -> Self {
-        Self {
-            lexer_rules: lexer_rules(),
-            grammar: grammar(),
-        }
-    }
-
-    fn parse(&self, value: &str) -> Result<Vec<Part>, Error> {
-        let lexemes = santiago::lexer::lex(&self.lexer_rules, value)?;
-        let parse_trees = santiago::parser::parse(&self.grammar, &lexemes)?;
-        let ast = parse_trees[0].as_abstract_syntax_tree();
-        Ok(ast_parts_to_parts(ast))
-    }
-}
-
-/// Types where each value has at most one successor and at most one
-/// predecessor.
-trait BoundedChain: Ord + Sized {
-    /// Return the successor of `self`, if exists.
-    fn succ(&self) -> Option<Self>;
-    /// Return the predecessor of `self`, if exists.
-    fn pred(&self) -> Option<Self>;
-}
-
-impl BoundedChain for u8 {
-    fn succ(&self) -> Option<Self> {
-        self.checked_add(1)
-    }
-
-    fn pred(&self) -> Option<Self> {
-        self.checked_sub(1)
-    }
-}
-
-/// Set defined by doubly inclusive intervals. When there's no interval, the
-/// set is an empty set.
-struct Intervals<T>(Vec<(T, T)>);
-
-impl<T> Default for Intervals<T> {
-    /// Construct an empty set.
-    fn default() -> Self {
-        Self(Vec::new())
-    }
-}
-
-impl<T> Intervals<T> {
-    fn push(&mut self, interval: (T, T)) {
-        self.0.push(interval);
-    }
-
-    fn append(&mut self, mut intervals: Vec<(T, T)>) {
-        self.0.append(&mut intervals);
-    }
-}
-
-impl<T: Ord> Intervals<T> {
-    fn contains(&self, value: &T) -> bool {
-        self.0.iter().any(|(a, b)| a <= value && value <= b)
-    }
-}
-
-impl<T: Ord + Copy> Intervals<T> {
-    /// Merge overlapping intervals.
-    fn merge(&mut self) {
-        self.0.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
-        self.0.dedup_by(|a, b| {
-            if a.0 <= b.1 {
-                b.1 = std::cmp::max(a.1, b.1);
-                true
-            } else {
-                false
-            }
-        });
-    }
-}
-
-impl<T: BoundedChain + Copy> Intervals<T> {
-    /// Remove the interval `r` from the union of `self`.
-    fn remove(&mut self, r: &(T, T)) {
-        let mut new_intervals = Vec::new();
-        self.0.retain_mut(|a| {
-            if a.0 == a.1 {
-                r.1 < a.0 || r.0 > a.1
-            } else {
-                if r.1 < a.0 || r.0 > a.1 {
-                    true
-                } else if r.1 == a.0 {
-                    // Since a.1 > a.0 == r.1, the successor of r.1 must exist.
-                    a.0 = r.1.succ().unwrap();
-                    true
-                } else if r.0 == a.1 {
-                    // Since a.0 < a.1 == r.0, the predecessor of r.0 must exist.
-                    a.1 = r.0.pred().unwrap();
-                    true
-                } else if r.0 <= a.0 && r.1 > a.0 && r.1 < a.1 {
-                    // Since a.1 > r.1, the successor of r.1 must exist.
-                    a.0 = r.1.succ().unwrap();
-                    true
-                } else if r.0 > a.0 /* && r.1 > a.0 */ && r.1 < a.1 {
-                    // Since r.1 < a.1, the successor of r.1 must exist.
-                    new_intervals.push((r.1.succ().unwrap(), a.1));
-                    // Since a.0 < r.0, the predecessor of r.0 must exist.
-                    a.1 = r.0.pred().unwrap();
-                    true
-                } else if r.1 >= a.1 && r.0 > a.0 && r.0 < a.1 {
-                    // Since a.0 < r.0, the predecessor of r.0 must exist.
-                    a.1 = r.0.pred().unwrap();
-                    true
-                } else if r.1 >= a.1 && r.0 <= a.0 {
-                    false
-                } else if r.1 == a.1 && r.0 > a.0 {
-                    // Since a.0 < r.0, the predecessor of r.0 must exist.
-                    a.1 = r.0.pred().unwrap();
-                    true
-                } else if r.0 == a.0 && r.1 < a.1 {
-                    // Since r.1 < a.1, the successor of r.1 must exist.
-                    a.0 = r.1.succ().unwrap();
-                    true
-                } else {
-                    unreachable!()
-                }
-            }
-        });
-        self.0.append(&mut new_intervals);
-    }
-}
-
-/// Represents the '@'. When interpreted as a char, it's '@'. When interpreted
-/// as an ASCII range, it's `a-z,A-Z,192-255`, per
-/// https://vimhelp.org/options.txt.html#%27isfname%27:
-///
-/// > Normally these are the characters a to z and A to Z, plus accented
-///   characters.
-struct AtSymbol;
-
-impl From<AtSymbol> for u8 {
-    fn from(_: AtSymbol) -> Self {
-        64
-    }
-}
-
-impl From<AtSymbol> for Vec<(u8, u8)> {
-    fn from(_: AtSymbol) -> Self {
-        vec![(65, 90), (97, 122), (192, 255)]
-    }
-}
-
-impl TryFrom<CharSpec> for u8 {
-    type Error = AtSymbol;
-
-    /// Convert `value` to `char`, treating '@' as a special case.
-    fn try_from(value: CharSpec) -> Result<Self, Self::Error> {
-        match value {
-            CharSpec::Number(num) => Ok(num),
-            CharSpec::Char(ch) => {
-                if ch == '@' {
-                    Err(AtSymbol)
-                } else {
-                    Ok(super::ascii_or(ch).unwrap_or_else(|| {
-                        panic!("CharSpec holds non-ASCII char: {}", ch)
-                    }))
-                }
-            }
-        }
-    }
-}
-
-impl TryFrom<Item> for (u8, u8) {
-    type Error = AtSymbol;
-
-    /// Convert `value` to `(u8, u8)`, treating '@' outside a range as a
-    /// special case.
-    fn try_from(value: Item) -> Result<Self, Self::Error> {
-        match value {
-            Item::CharSpec(cs) => u8::try_from(cs).map(|ch| (ch, ch)),
-            Item::Range(lhs, rhs) => {
-                let lhs = lhs.try_into().unwrap_or_else(Into::into);
-                let rhs = rhs.try_into().unwrap_or_else(Into::into);
-                Ok((lhs, rhs))
-            }
-        }
-    }
-}
+use super::utils::Set256;
 
 /// Predicate for whether an ASCII or unicode is a word.
+#[derive(Debug)]
 pub struct WordPredicate {
-    /// Set of ASCII characters defined by doubly inclusive intervals. When
-    /// there's no interval, the set is an empty set.
-    ascii_set: Intervals<u8>,
+    /// Set of ASCII characters.
+    ascii_set: Set256,
     /// True if '@' is included.
     include_alphabetic: bool,
+}
+
+trait Cursor<T> {
+    fn next(&self, i: &mut usize) -> &T;
+    fn prev(&self, i: &mut usize) -> &T;
+}
+
+impl<T> Cursor<T> for [T] {
+    fn next(&self, i: &mut usize) -> &T {
+        let c = &self[*i];
+        *i += 1;
+        c
+    }
+
+    fn prev(&self, i: &mut usize) -> &T {
+        *i -= 1;
+        &self[*i]
+    }
 }
 
 impl WordPredicate {
     fn new() -> Self {
         Self {
-            ascii_set: Intervals::default(),
+            ascii_set: Set256::default(),
             include_alphabetic: false,
         }
     }
 
-    fn add_part(&mut self, part: Part) {
-        match part {
-            Part::Part(item) => match item.try_into() {
-                Ok(interval) => {
-                    self.ascii_set.push(interval);
-                    self.ascii_set.merge();
-                }
-                Err(at) => {
-                    let at_intervals: Vec<_> = at.into();
-                    self.ascii_set.append(at_intervals);
-                    self.ascii_set.merge();
-                    self.include_alphabetic = true;
-                }
-            },
-            Part::NegPart(item) => match item.try_into() {
-                Ok(interval) => self.ascii_set.remove(&interval),
-                Err(at) => {
-                    let at_intervals: Vec<_> = at.into();
-                    for interval in at_intervals.iter() {
-                        self.ascii_set.remove(interval);
-                    }
-                    self.include_alphabetic = false;
-                }
-            },
-        }
-    }
-
-    /// Try to construct a `WordPredicate` from `'iskeyword'` option value.
-    pub fn try_from_isk(
-        isk_parser: &IskParser,
-        value: &str,
-    ) -> Result<Self, Error> {
+    pub fn from_isk_opt(value: &str) -> Option<Self> {
         let mut wp = Self::new();
-        for part in isk_parser.parse(value)? {
-            wp.add_part(part);
+        let chars = value.as_bytes();
+        let mut i = 0;
+        let n = chars.len();
+        const ZERO: u8 = '0' as u8;
+        const NINE: u8 = ZERO + 9;
+        // The pre-computed segment values of '@' in `Set256`.
+        const ALPHA: [u64; 4] =
+            [0, 0x7FFFFFE07FFFFFE, 0x420040000000000, 0xFF7FFFFFFF7FFFFF];
+
+        // Consume next arg, which is either an unsigned integer or an ascii
+        // char (u8). Return None if it's an integer that overflows u8, or
+        // there is no next arg.
+        let expect_arg = |i: &mut usize| -> Option<u8> {
+            if *i >= n {
+                return None;
+            }
+            let c = chars.next(i);
+            if (ZERO..=NINE).contains(c) {
+                let mut num = (*c - ZERO) as u32;
+                while *i < n {
+                    let c = chars.next(i);
+                    if (ZERO..=NINE).contains(c) {
+                        num = num * 10 + (*c - ZERO) as u32;
+                        if num > 255 {
+                            return None;
+                        }
+                    } else {
+                        chars.prev(i);
+                        break;
+                    }
+                }
+                Some(num as u8)
+            } else {
+                Some(*c)
+            }
+        };
+
+        // Assert the next char is `c`. Consume and return `c` if it's indeed
+        // the case. Return None if there's no next char, or it's not the same
+        // as `c`.
+        let expect_char = |c: u8, i: &mut usize| -> Option<u8> {
+            if *i >= n {
+                return None;
+            }
+            if chars.next(i) != &c {
+                chars.prev(i);
+                return None;
+            }
+            Some(c)
+        };
+
+        while i < n {
+            let c1 = chars.next(&mut i);
+            if c1 == &b'^' {
+                // If a leading '^' is found, ...
+                if i >= n {
+                    wp.ascii_set.set(b'^');
+                } else {
+                    // Some arg follows '^'; we will clear it.
+                    let lhs = expect_arg(&mut i)?;
+                    if i >= n {
+                        if lhs == b'@' {
+                            // i.e. ^@
+                            wp.ascii_set.clear_segments(ALPHA);
+                            wp.include_alphabetic = false;
+                        } else {
+                            // e.g. ^a or ^48
+                            wp.ascii_set.clear(lhs);
+                        }
+                    } else {
+                        if expect_char(b',', &mut i).is_some() {
+                            // If next char is ',', consume it.
+                            if lhs == b'@' {
+                                // i.e. ^@
+                                wp.ascii_set.clear_segments(ALPHA);
+                                wp.include_alphabetic = false;
+                            } else {
+                                // e.g. ^a or ^48
+                                wp.ascii_set.clear(lhs);
+                            }
+                            if i >= n {
+                                // Trailing ',' is forbidden.
+                                return None;
+                            }
+                        } else {
+                            // Otherwise, it must be '-'. Else, errors out.
+                            expect_char(b'-', &mut i)?;
+                            let rhs = expect_arg(&mut i)?;
+                            if lhs > rhs {
+                                return None;
+                            }
+                            // e.g. ^a-b or ^48-57 or ^97-z
+                            wp.ascii_set.clear_range(lhs, rhs);
+                            if i < n {
+                                // Consume the next ',' if not at eos.
+                                expect_char(b',', &mut i)?;
+                                if i >= n {
+                                    // Trailing ',' is forbidden.
+                                    return None;
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                chars.prev(&mut i);
+                let lhs = expect_arg(&mut i)?;
+                if i >= n {
+                    if lhs == b'@' {
+                        // i.e. @
+                        wp.ascii_set.set_segments(ALPHA);
+                        wp.include_alphabetic = true;
+                    } else {
+                        // e.g. a or 48
+                        wp.ascii_set.set(lhs);
+                    }
+                } else {
+                    if expect_char(b',', &mut i).is_some() {
+                        // If next char is ',', consume it.
+                        if lhs == b'@' {
+                            // i.e. @
+                            wp.ascii_set.set_segments(ALPHA);
+                            wp.include_alphabetic = true;
+                        } else {
+                            // e.g. a or 48
+                            wp.ascii_set.set(lhs);
+                        }
+                        if i >= n {
+                            // Trailing ',' is forbidden.
+                            return None;
+                        }
+                    } else {
+                        // Otherwise, it must be '-'. Else, errors out.
+                        expect_char(b'-', &mut i)?;
+                        let rhs = expect_arg(&mut i)?;
+                        if lhs > rhs {
+                            return None;
+                        }
+                        // e.g. a-b or 48-57 or 97-z
+                        wp.ascii_set.set_range(lhs, rhs);
+                        if i < n {
+                            // Consume the next ',' if not at eos.
+                            expect_char(b',', &mut i)?;
+                            if i >= n {
+                                // Trailing ',' is forbidden.
+                                return None;
+                            }
+                        }
+                    }
+                }
+            }
         }
-        Ok(wp)
+
+        Some(wp)
     }
 
     /// Check if `ascii` is a word.
     pub fn is_ascii_word(&self, ascii: u8) -> bool {
-        self.ascii_set.contains(&ascii)
+        self.ascii_set.contains(ascii)
     }
 
     /// Check if a unicode alphabet like 汉字 is a word.
@@ -577,482 +221,243 @@ impl WordPredicate {
 }
 
 impl TryFrom<&str> for WordPredicate {
-    type Error = Error;
+    type Error = ();
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let isk_parser = IskParser::new();
-        WordPredicate::try_from_isk(&isk_parser, value)
+        WordPredicate::from_isk_opt(value).ok_or(())
     }
 }
 
 impl TryFrom<String> for WordPredicate {
-    type Error = Error;
+    type Error = ();
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let isk_parser = IskParser::new();
-        WordPredicate::try_from_isk(&isk_parser, &value)
+        WordPredicate::from_isk_opt(&value).ok_or(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::token::utils::Set256;
 
-    fn parse_isk_test(
-        parser: &IskParser,
-        value: &str,
-    ) -> Result<Vec<Part>, Error> {
-        let parts = parser.parse(value);
-        parts
+    use super::WordPredicate;
+
+    fn get_ascii_set(isk: &str) -> Result<Set256, ()> {
+        WordPredicate::from_isk_opt(isk)
+            .map(|wp| wp.ascii_set)
+            .ok_or(())
+    }
+
+    macro_rules! assert_contains {
+        ($set:expr, $($i:literal..=$j:literal),*) => {
+            $(
+                assert!($set.all_range($i, $j));
+            )*
+        };
+    }
+
+    macro_rules! assert_not_contains {
+        ($set:expr, $($i:literal..=$j:literal),*) => {
+            $(
+                assert!(!$set.any_range($i, $j));
+            )*
+        };
     }
 
     #[test]
-    fn test_grammar() {
-        let parser = IskParser::new();
+    fn test_parse_isk() -> Result<(), ()> {
+        let s = get_ascii_set("")?;
+        assert_not_contains!(s, 0..=255);
 
-        assert!(parse_isk_test(&parser, "").unwrap().is_empty());
-        assert_eq!(
-            parse_isk_test(&parser, "48").unwrap(),
-            vec![Part::Part(Item::CharSpec(CharSpec::Number(48)))]
+        let s = get_ascii_set("48")?;
+        assert_contains!(s, 48..=48);
+        assert_not_contains!(s, 0..=47, 49..=255);
+
+        let s = get_ascii_set("-")?;
+        assert_contains!(s, b'-'..=b'-');
+        assert_not_contains!(s, 0..=0x2C, 0x2E..=255);
+
+        let s = get_ascii_set("#-43")?;
+        assert_contains!(s, b'#'..=43);
+        assert_not_contains!(s, 0..=0x22, 44..=255);
+
+        let s = get_ascii_set("128-140")?;
+        assert_contains!(s, 128..=140);
+        assert_not_contains!(s, 0..=127, 141..=255);
+
+        let s = get_ascii_set("--57")?;
+        assert_contains!(s, b'-'..=57);
+        assert_not_contains!(s, 0..=44, 58..=255);
+
+        let s = get_ascii_set("---")?;
+        assert_contains!(s, b'-'..=b'-');
+        assert_not_contains!(s, 0..=44, 46..=255);
+
+        let s = get_ascii_set("^a-z")?;
+        assert_not_contains!(s, 0..=255);
+
+        let s = get_ascii_set("93-95,^^")?;
+        assert_contains!(s, 93..=93, 95..=95);
+        assert_not_contains!(s, 0..=92, 94..=94, 96..=255);
+
+        let s = get_ascii_set("^93-^")?;
+        assert_not_contains!(s, 0..=255);
+
+        let s = get_ascii_set("^48-^,,,^")?;
+        assert_contains!(s, b','..=b',', b'^'..=b'^');
+        assert_not_contains!(s, 0..=43, 45..=93, 95..=255);
+
+        let s = get_ascii_set("48-57,93-^")?;
+        assert_contains!(s, 48..=57, 93..=b'^');
+        assert_not_contains!(s, 0..=47, 58..=92, 95..=255);
+
+        let s = get_ascii_set("^a-z,#,^")?;
+        assert_contains!(s, b'#'..=b'#', b'^'..=b'^');
+        assert_not_contains!(s, 0..=34, 36..=93, 95..=255);
+
+        let s = get_ascii_set("^a-z,#,^^")?;
+        assert_contains!(s, b'#'..=b'#');
+        assert_not_contains!(s, 0..=34, 36..=255);
+
+        assert!(get_ascii_set("^-^").is_err());
+        assert!(get_ascii_set(r"\\").is_err());
+        assert!(get_ascii_set(r"a-z,\\,.").is_err());
+
+        let s = get_ascii_set("@")?;
+        assert_contains!(
+            s,
+            65..=90,
+            97..=122,
+            170..=170,
+            181..=181,
+            186..=186,
+            192..=214,
+            216..=246,
+            248..=255
         );
-        assert_eq!(
-            parse_isk_test(&parser, "-").unwrap(),
-            vec![Part::Part(Item::CharSpec(CharSpec::Char('-')))]
+        assert_not_contains!(
+            s,
+            0..=64,
+            91..=96,
+            123..=169,
+            171..=180,
+            182..=185,
+            187..=191,
+            215..=215,
+            247..=247
         );
-        assert_eq!(
-            parse_isk_test(&parser, "#-43").unwrap(),
-            vec![Part::Part(Item::Range(
-                CharSpec::Char('#'),
-                CharSpec::Number(43)
-            ))]
+
+        let s = get_ascii_set("@-@")?;
+        assert_contains!(s, b'@'..=b'@');
+        assert_not_contains!(s, 0..=63, 65..=255);
+
+        let s = get_ascii_set("@-65")?;
+        assert_contains!(s, b'@'..=65);
+        assert_not_contains!(s, 0..=63, 66..=255);
+
+        let s = get_ascii_set("@,^a-z,^A-Z")?;
+        assert_contains!(
+            s,
+            170..=170,
+            181..=181,
+            186..=186,
+            192..=214,
+            216..=246,
+            248..=255
         );
-        assert_eq!(
-            parse_isk_test(&parser, "128-140").unwrap(),
-            vec![Part::Part(Item::Range(
-                CharSpec::Number(128),
-                CharSpec::Number(140)
-            ))]
+        assert_not_contains!(
+            s,
+            0..=169,
+            171..=180,
+            182..=185,
+            187..=191,
+            215..=215,
+            247..=247
         );
-        assert_eq!(
-            parse_isk_test(&parser, "--57").unwrap(),
-            vec![Part::Part(Item::Range(
-                CharSpec::Char('-'),
-                CharSpec::Number(57)
-            ))]
+
+        let s = get_ascii_set("a-z,A-Z,@-@")?;
+        assert_contains!(s, b'a'..=b'z', b'A'..=b'Z', b'@'..=b'@');
+        assert_not_contains!(
+            s,
+            b'0'..=b'9',
+            171..=180,
+            182..=185,
+            187..=191,
+            215..=215,
+            247..=247
         );
-        assert_eq!(
-            parse_isk_test(&parser, "---").unwrap(),
-            vec![Part::Part(Item::Range(
-                CharSpec::Char('-'),
-                CharSpec::Char('-')
-            ))]
+
+        let s = get_ascii_set(",")?;
+        assert_contains!(s, b','..=b',');
+        assert_not_contains!(s, 0..=43, 45..=255);
+
+        let s = get_ascii_set(",,,")?;
+        assert_contains!(s, b','..=b',');
+        assert_not_contains!(s, 0..=43, 45..=255);
+
+        assert!(get_ascii_set(",,").is_err());
+        assert!(get_ascii_set(",,,,").is_err());
+
+        let s = get_ascii_set(r"48-57,,,_,\")?;
+        assert_contains!(
+            s,
+            b'0'..=b'9',
+            b','..=b',',
+            b'_'..=b'_',
+            b'\\'..=b'\\'
         );
-        assert_eq!(
-            parse_isk_test(&parser, "^a-z").unwrap(),
-            vec![Part::NegPart(Item::Range(
-                CharSpec::Char('a'),
-                CharSpec::Char('z')
-            ))]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "93-95,^^").unwrap(),
-            vec![
-                Part::Part(Item::Range(
-                    CharSpec::Number(93),
-                    CharSpec::Number(95)
-                )),
-                Part::NegPart(Item::CharSpec(CharSpec::Char('^')))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "^93-^").unwrap(),
-            vec![Part::NegPart(Item::Range(
-                CharSpec::Number(93),
-                CharSpec::Char('^')
-            ))]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "^48-^,,,^").unwrap(),
-            vec![
-                Part::NegPart(Item::Range(
-                    CharSpec::Number(48),
-                    CharSpec::Char('^')
-                )),
-                Part::Part(Item::CharSpec(CharSpec::Char(','))),
-                Part::Part(Item::CharSpec(CharSpec::Char('^')))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "48-57,93-^").unwrap(),
-            vec![
-                Part::Part(Item::Range(
-                    CharSpec::Number(48),
-                    CharSpec::Number(57)
-                )),
-                Part::Part(Item::Range(
-                    CharSpec::Number(93),
-                    CharSpec::Char('^')
-                ))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "^a-z,#,^").unwrap(),
-            vec![
-                Part::NegPart(Item::Range(
-                    CharSpec::Char('a'),
-                    CharSpec::Char('z')
-                )),
-                Part::Part(Item::CharSpec(CharSpec::Char('#'))),
-                Part::Part(Item::CharSpec(CharSpec::Char('^')))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "^a-z,#,^^").unwrap(),
-            vec![
-                Part::NegPart(Item::Range(
-                    CharSpec::Char('a'),
-                    CharSpec::Char('z')
-                )),
-                Part::Part(Item::CharSpec(CharSpec::Char('#'))),
-                Part::NegPart(Item::CharSpec(CharSpec::Char('^')))
-            ]
-        );
-        parse_isk_test(&parser, "^-^").unwrap_err();
-        parse_isk_test(&parser, r"\\").unwrap_err();
-        parse_isk_test(&parser, r"a-z,\\,.").unwrap_err();
-        assert_eq!(
-            parse_isk_test(&parser, "@").unwrap(),
-            vec![Part::Part(Item::CharSpec(CharSpec::Char('@')))]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "@-@").unwrap(),
-            vec![Part::Part(Item::Range(
-                CharSpec::Char('@'),
-                CharSpec::Char('@')
-            ))]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "@-65").unwrap(),
-            vec![Part::Part(Item::Range(
-                CharSpec::Char('@'),
-                CharSpec::Number(65)
-            ))]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "_,-,128-140,^#-43").unwrap(),
-            vec![
-                Part::Part(Item::CharSpec(CharSpec::Char('_'))),
-                Part::Part(Item::CharSpec(CharSpec::Char('-'))),
-                Part::Part(Item::Range(
-                    CharSpec::Number(128),
-                    CharSpec::Number(140)
-                )),
-                Part::NegPart(Item::Range(
-                    CharSpec::Char('#'),
-                    CharSpec::Number(43)
-                ))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "@,^a-z").unwrap(),
-            vec![
-                Part::Part(Item::CharSpec(CharSpec::Char('@'))),
-                Part::NegPart(Item::Range(
-                    CharSpec::Char('a'),
-                    CharSpec::Char('z')
-                ))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "a-z,A-Z,@-@").unwrap(),
-            vec![
-                Part::Part(Item::Range(
-                    CharSpec::Char('a'),
-                    CharSpec::Char('z')
-                )),
-                Part::Part(Item::Range(
-                    CharSpec::Char('A'),
-                    CharSpec::Char('Z')
-                )),
-                Part::Part(Item::Range(
-                    CharSpec::Char('@'),
-                    CharSpec::Char('@')
-                ))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, ",").unwrap(),
-            vec![Part::Part(Item::CharSpec(CharSpec::Char(',')))]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, ",,,").unwrap(),
-            vec![
-                Part::Part(Item::CharSpec(CharSpec::Char(','))),
-                Part::Part(Item::CharSpec(CharSpec::Char(',')))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "48-57,,,_").unwrap(),
-            vec![
-                Part::Part(Item::Range(
-                    CharSpec::Number(48),
-                    CharSpec::Number(57)
-                )),
-                Part::Part(Item::CharSpec(CharSpec::Char(','))),
-                Part::Part(Item::CharSpec(CharSpec::Char('_')))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "32-~,^,,9").unwrap(),
-            vec![
-                Part::Part(Item::Range(
-                    CharSpec::Number(32),
-                    CharSpec::Char('~')
-                )),
-                Part::NegPart(Item::CharSpec(CharSpec::Char(','))),
-                Part::Part(Item::CharSpec(CharSpec::Number(9)))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, ",,^,,^^,^").unwrap(),
-            vec![
-                Part::Part(Item::CharSpec(CharSpec::Char(','))),
-                Part::NegPart(Item::CharSpec(CharSpec::Char(','))),
-                Part::NegPart(Item::CharSpec(CharSpec::Char('^'))),
-                Part::Part(Item::CharSpec(CharSpec::Char('^')))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "^^,,,^,,^").unwrap(),
-            vec![
-                Part::NegPart(Item::CharSpec(CharSpec::Char('^'))),
-                Part::Part(Item::CharSpec(CharSpec::Char(','))),
-                Part::NegPart(Item::CharSpec(CharSpec::Char(','))),
-                Part::Part(Item::CharSpec(CharSpec::Char('^')))
-            ]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "^^-^").unwrap(),
-            vec![Part::NegPart(Item::Range(
-                CharSpec::Char('^'),
-                CharSpec::Char('^')
-            ))]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "^").unwrap(),
-            vec![Part::Part(Item::CharSpec(CharSpec::Char('^')))]
-        );
-        assert_eq!(
-            parse_isk_test(&parser, "^^").unwrap(),
-            vec![Part::NegPart(Item::CharSpec(CharSpec::Char('^')))]
-        );
-        // 'iskeyword' default for Win32.
-        assert_eq!(
-            parse_isk_test(&parser, "@,48-57,_,128-167,224-235").unwrap(),
-            vec![
-                Part::Part(Item::CharSpec(CharSpec::Char('@'))),
-                Part::Part(Item::Range(
-                    CharSpec::Number(48),
-                    CharSpec::Number(57)
-                )),
-                Part::Part(Item::CharSpec(CharSpec::Char('_'))),
-                Part::Part(Item::Range(
-                    CharSpec::Number(128),
-                    CharSpec::Number(167)
-                )),
-                Part::Part(Item::Range(
-                    CharSpec::Number(224),
-                    CharSpec::Number(235)
-                )),
-            ]
-        );
+        assert_not_contains!(s, 0..=43, 45..=47, 58..=91, 93..=94, 96..=255);
+
+        let s = get_ascii_set("32-~,^,,9")?;
+        assert_contains!(s, 32..=43, 45..=b'~', 9..=9);
+        assert_not_contains!(s, 0..=8, 10..=31, 44..=44, 127..=255);
+
+        let s = get_ascii_set(",,^,,^^,^")?;
+        assert_contains!(s, b'^'..=b'^');
+        assert_not_contains!(s, 0..=93, 95..=255);
+
+        let s = get_ascii_set("^^,,,^,,^")?;
+        assert_contains!(s, b'^'..=b'^');
+        assert_not_contains!(s, 0..=93, 95..=255);
+
+        let s = get_ascii_set("^^-^")?;
+        assert_not_contains!(s, 0..=255);
+
+        let s = get_ascii_set("0-255,^^-^")?;
+        assert_contains!(s, 0..=93, 95..=255);
+        assert_not_contains!(s, b'^'..=b'^');
+
+        let s = get_ascii_set("0-255,^^")?;
+        assert_contains!(s, 0..=93, 95..=255);
+        assert_not_contains!(s, b'^'..=b'^');
+
+        let s = get_ascii_set("^")?;
+        assert_contains!(s, b'^'..=b'^');
+        assert_not_contains!(s, 0..=93, 95..=255);
+
+        let s = get_ascii_set("^^")?;
+        assert_not_contains!(s, 0..=255);
+
         // 'iskeyword' value for vim help.
-        assert_eq!(
-            parse_isk_test(&parser, r#"!-~,^*,^|,^",192-255"#).unwrap(),
-            vec![
-                Part::Part(Item::Range(
-                    CharSpec::Char('!'),
-                    CharSpec::Char('~')
-                )),
-                Part::NegPart(Item::CharSpec(CharSpec::Char('*'))),
-                Part::NegPart(Item::CharSpec(CharSpec::Char('|'))),
-                Part::NegPart(Item::CharSpec(CharSpec::Char('"'))),
-                Part::Part(Item::Range(
-                    CharSpec::Number(192),
-                    CharSpec::Number(255)
-                ))
-            ]
-        );
-        // Recommended 'iskeyword' value for C.
-        assert_eq!(
-            parse_isk_test(&parser, "a-z,A-Z,48-57,_,.,-,>").unwrap(),
-            vec![
-                Part::Part(Item::Range(
-                    CharSpec::Char('a'),
-                    CharSpec::Char('z')
-                )),
-                Part::Part(Item::Range(
-                    CharSpec::Char('A'),
-                    CharSpec::Char('Z')
-                )),
-                Part::Part(Item::Range(
-                    CharSpec::Number(48),
-                    CharSpec::Number(57)
-                )),
-                Part::Part(Item::CharSpec(CharSpec::Char('_'))),
-                Part::Part(Item::CharSpec(CharSpec::Char('.'))),
-                Part::Part(Item::CharSpec(CharSpec::Char('-'))),
-                Part::Part(Item::CharSpec(CharSpec::Char('>')))
-            ]
-        );
-    }
+        let s = get_ascii_set(r#"!-~,^*,^|,^",192-255"#)?;
+        assert_contains!(s, 33..=33, 35..=41, 43..=123, 125..=126, 192..=255);
+        assert_not_contains!(s, 0..=32, 34..=34, 42..=42, 124..=124, 127..=191);
 
-    fn merge_intervals_test<T: Ord + Copy>(
-        intervals: Vec<(T, T)>,
-    ) -> Vec<(T, T)> {
-        let mut intervals = Intervals(intervals);
-        intervals.merge();
-        intervals.0
-    }
-
-    #[test]
-    fn test_merge_intervals() {
-        let itvls = vec![(1, 5), (6, 7)];
-        assert_eq!(merge_intervals_test(itvls), vec![(1, 5), (6, 7)]);
-
-        let itvls = vec![(1, 5), (5, 7)];
-        assert_eq!(merge_intervals_test(itvls), vec![(1, 7)]);
-
-        let itvls = vec![(1, 5), (3, 7)];
-        assert_eq!(merge_intervals_test(itvls), vec![(1, 7)]);
-
-        let itvls = vec![(1, 5), (0, 7)];
-        assert_eq!(merge_intervals_test(itvls), vec![(0, 7)]);
-
-        let itvls = vec![(1, 5), (3, 4)];
-        assert_eq!(merge_intervals_test(itvls), vec![(1, 5)]);
-
-        let itvls = vec![(1, 5), (1, 5)];
-        assert_eq!(merge_intervals_test(itvls), vec![(1, 5)]);
-
-        let itvls = vec![(1, 5), (0, 3)];
-        assert_eq!(merge_intervals_test(itvls), vec![(0, 5)]);
-
-        let itvls = vec![(1, 5), (0, 1)];
-        assert_eq!(merge_intervals_test(itvls), vec![(0, 5)]);
-
-        let itvls = vec![(1, 5), (0, 0)];
-        assert_eq!(merge_intervals_test(itvls), vec![(0, 0), (1, 5)]);
-
-        let itvls = vec![(1, 5), (7, 10), (6, 7)];
-        assert_eq!(merge_intervals_test(itvls), vec![(1, 5), (6, 10)]);
-
-        let itvls = vec![(1, 5), (7, 10), (3, 8)];
-        assert_eq!(merge_intervals_test(itvls), vec![(1, 10)]);
-
-        let itvls = vec![(1, 5), (8, 10), (15, 17), (7, 11)];
-        assert_eq!(
-            merge_intervals_test(itvls),
-            vec![(1, 5), (7, 11), (15, 17)]
+        let s = get_ascii_set("a-z,A-Z,48-57,_,.,-,>")?;
+        assert_contains!(
+            s,
+            b'a'..=b'z',
+            b'A'..=b'Z',
+            48..=57,
+            b'_'..=b'_',
+            b'.'..=b'.',
+            b'-'..=b'-',
+            b'>'..=b'>'
         );
 
-        let itvls = vec![(1, 5), (8, 10), (15, 17), (5, 8)];
-        assert_eq!(merge_intervals_test(itvls), vec![(1, 10), (15, 17)]);
+        let s = get_ascii_set("@,^A,48-57")?;
+        assert!(!s.contains(b'A'));
 
-        let itvls = vec![(1, 5), (8, 10), (15, 17), (2, 8), (9, 20)];
-        assert_eq!(merge_intervals_test(itvls), vec![(1, 20)]);
-    }
-
-    #[test]
-    fn test_retain_mut() {
-        fn rule(e: &mut i32) -> bool {
-            if e != &0 {
-                *e *= 2;
-                true
-            } else {
-                false
-            }
-        }
-
-        let mut v = vec![];
-        v.retain_mut(rule);
-        assert!(v.is_empty());
-
-        let mut v = vec![0];
-        v.retain_mut(rule);
-        assert!(v.is_empty());
-
-        let mut v = vec![2];
-        v.retain_mut(rule);
-        assert_eq!(v, vec![4]);
-
-        let mut v = vec![2, 0];
-        v.retain_mut(rule);
-        assert_eq!(v, vec![4]);
-
-        let mut v = vec![0, 2];
-        v.retain_mut(rule);
-        assert_eq!(v, vec![4]);
-
-        let mut v = vec![0, 2, 0];
-        v.retain_mut(rule);
-        assert_eq!(v, vec![4]);
-
-        let mut v = vec![2, 3, 0, 0, 1, 0, 4, 5, 6, 0];
-        v.retain_mut(rule);
-        assert_eq!(v, vec![4, 6, 2, 8, 10, 12]);
-
-        let mut v = vec![0, 0, 2, 3, 0, 0, 1, 0, 4, 5, 6, 0];
-        v.retain_mut(rule);
-        assert_eq!(v, vec![4, 6, 2, 8, 10, 12]);
-    }
-
-    fn remove_interval_test<T: BoundedChain + Copy>(
-        intervals: Vec<(T, T)>,
-        r: &(T, T),
-    ) -> Vec<(T, T)> {
-        let mut intervals = Intervals(intervals);
-        intervals.remove(r);
-        intervals.0
-    }
-
-    #[test]
-    fn test_remove_interval() {
-        assert_eq!(remove_interval_test(vec![(5, 10)], &(0, 3)), vec![(5, 10)]);
-        assert_eq!(remove_interval_test(vec![(5, 10)], &(0, 5)), vec![(6, 10)]);
-        assert_eq!(remove_interval_test(vec![(5, 10)], &(0, 6)), vec![(7, 10)]);
-        assert!(remove_interval_test(vec![(5, 10)], &(0, 10)).is_empty());
-        assert!(remove_interval_test(vec![(5, 10)], &(0, 13)).is_empty());
-        assert_eq!(remove_interval_test(vec![(5, 10)], &(5, 5)), vec![(6, 10)]);
-        assert_eq!(remove_interval_test(vec![(5, 10)], &(5, 6)), vec![(7, 10)]);
-        assert!(remove_interval_test(vec![(5, 10)], &(5, 10)).is_empty());
-        assert_eq!(
-            remove_interval_test(vec![(5, 10)], &(6, 6)),
-            vec![(5, 5), (7, 10)]
-        );
-        assert_eq!(
-            remove_interval_test(vec![(5, 10)], &(6, 8)),
-            vec![(5, 5), (9, 10)]
-        );
-        assert_eq!(remove_interval_test(vec![(5, 10)], &(6, 10)), vec![(5, 5)]);
-        assert_eq!(remove_interval_test(vec![(5, 10)], &(6, 13)), vec![(5, 5)]);
-        assert_eq!(
-            remove_interval_test(vec![(5, 10)], &(10, 10)),
-            vec![(5, 9)]
-        );
-        assert_eq!(
-            remove_interval_test(vec![(5, 10)], &(10, 12)),
-            vec![(5, 9)]
-        );
-        assert_eq!(
-            remove_interval_test(vec![(5, 10)], &(11, 13)),
-            vec![(5, 10)]
-        );
-        assert_eq!(remove_interval_test(vec![(5, 5)], &(0, 3)), vec![(5, 5)]);
-        assert!(remove_interval_test(vec![(5, 5)], &(0, 5)).is_empty());
-        assert!(remove_interval_test(vec![(5, 5)], &(0, 6)).is_empty());
-        assert!(remove_interval_test(vec![(5, 5)], &(5, 5)).is_empty());
-        assert!(remove_interval_test(vec![(5, 5)], &(5, 7)).is_empty());
-        assert_eq!(remove_interval_test(vec![(5, 5)], &(7, 8)), vec![(5, 5)]);
+        Ok(())
     }
 }

--- a/rust_backend/jieba_vim_rs_core/src/token/utils.rs
+++ b/rust_backend/jieba_vim_rs_core/src/token/utils.rs
@@ -1,3 +1,17 @@
+// Copyright 2025-2026 Kaiwen Wu. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy
+// of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
 use super::tokenize::{Token, TokenLike};
 
 /// Get the index of the token in `tokens` that covers `col`. Return `None` if
@@ -26,12 +40,312 @@ pub fn ascii_or(c: char) -> Option<u8> {
     }
 }
 
+mod set256 {
+    use std::fmt;
+
+    const fn max(x: u8, y: u8) -> u8 {
+        if x > y { x } else { y }
+    }
+
+    const fn min(x: u8, y: u8) -> u8 {
+        if x < y { x } else { y }
+    }
+
+    const fn get_seg_range_op([i, j]: [u8; 2]) -> u64 {
+        if i > j {
+            return 0;
+        }
+        assert!(j < 64);
+        let n = j - i + 1;
+        (u64::MAX >> (64 - n)) << i
+    }
+
+    const fn split_range(i: u8, j: u8) -> [[u8; 2]; 4] {
+        let l = [0, 64, 128, 192];
+        let r = [63, 127, 191, 255];
+        let il = [max(i, l[0]), max(i, l[1]), max(i, l[2]), max(i, l[3])];
+        let jr = [min(j, r[0]), min(j, r[1]), min(j, r[2]), min(j, r[3])];
+
+        const fn which(il: u8, jr: u8, l: u8) -> [u8; 2] {
+            if il <= jr { [il - l, jr - l] } else { [1, 0] }
+        }
+
+        [
+            which(il[0], jr[0], l[0]),
+            which(il[1], jr[1], l[1]),
+            which(il[2], jr[2], l[2]),
+            which(il[3], jr[3], l[3]),
+        ]
+    }
+
+    const fn get_range_op(i: u8, j: u8) -> [u64; 4] {
+        let a = split_range(i, j);
+        [
+            get_seg_range_op(a[0]),
+            get_seg_range_op(a[1]),
+            get_seg_range_op(a[2]),
+            get_seg_range_op(a[3]),
+        ]
+    }
+
+    /// A bitset with 256 slots.
+    #[derive(Default)]
+    pub struct Set256 {
+        segments: [u64; 4],
+    }
+
+    impl fmt::Debug for Set256 {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "{:0>64b}{:0>64b}{:0>64b}{:0>64b}",
+                self.segments[3],
+                self.segments[2],
+                self.segments[1],
+                self.segments[0]
+            )
+        }
+    }
+
+    impl Set256 {
+        #[inline]
+        const fn set_segment(&mut self, s: usize, op: u64) {
+            self.segments[s] |= op;
+        }
+
+        #[inline]
+        const fn clear_segment(&mut self, s: usize, op: u64) {
+            self.segments[s] &= !op;
+        }
+
+        #[cfg(test)]
+        #[inline]
+        const fn all_segment(&self, s: usize, op: u64) -> bool {
+            (self.segments[s] & op) == op
+        }
+
+        #[inline]
+        const fn any_segment(&self, s: usize, op: u64) -> bool {
+            (self.segments[s] & op) > 0
+        }
+
+        pub const fn set_segments(&mut self, op: [u64; 4]) {
+            self.set_segment(0, op[0]);
+            self.set_segment(1, op[1]);
+            self.set_segment(2, op[2]);
+            self.set_segment(3, op[3]);
+        }
+
+        pub const fn clear_segments(&mut self, op: [u64; 4]) {
+            self.clear_segment(0, op[0]);
+            self.clear_segment(1, op[1]);
+            self.clear_segment(2, op[2]);
+            self.clear_segment(3, op[3]);
+        }
+
+        #[cfg(test)]
+        pub const fn all_segments(&self, op: [u64; 4]) -> bool {
+            self.all_segment(0, op[0])
+                && self.all_segment(1, op[1])
+                && self.all_segment(2, op[2])
+                && self.all_segment(3, op[3])
+        }
+
+        pub const fn any_segments(&self, op: [u64; 4]) -> bool {
+            self.any_segment(0, op[0])
+                || self.any_segment(1, op[1])
+                || self.any_segment(2, op[2])
+                || self.any_segment(3, op[3])
+        }
+
+        /// Set range inclusive. Panics if i > j.
+        pub const fn set_range(&mut self, i: u8, j: u8) {
+            assert!(i <= j);
+            self.set_segments(get_range_op(i, j));
+        }
+
+        pub const fn clear_range(&mut self, i: u8, j: u8) {
+            assert!(i <= j);
+            self.clear_segments(get_range_op(i, j));
+        }
+
+        #[cfg(test)]
+        pub const fn all_range(&self, i: u8, j: u8) -> bool {
+            assert!(i <= j);
+            self.all_segments(get_range_op(i, j))
+        }
+
+        pub const fn any_range(&self, i: u8, j: u8) -> bool {
+            assert!(i <= j);
+            self.any_segments(get_range_op(i, j))
+        }
+
+        pub const fn set(&mut self, i: u8) {
+            self.set_range(i, i);
+        }
+
+        pub const fn clear(&mut self, i: u8) {
+            self.clear_range(i, i);
+        }
+
+        pub const fn contains(&self, i: u8) -> bool {
+            self.any_range(i, i)
+        }
+    }
+}
+
+pub use set256::Set256;
+
 #[cfg(test)]
 mod tests {
-    use super::index_tokens;
+    use super::{Set256, index_tokens};
 
     #[test]
     fn test_index_tokens() {
         assert_eq!(index_tokens(&[], 0), None);
+    }
+
+    #[test]
+    fn test_set256() {
+        for i in 0..=255 {
+            let mut s = Set256::default();
+            s.set(i);
+            assert!(s.all_range(i, i));
+            assert!(s.any_range(i, i));
+            if i == 0 {
+                assert!(!s.any_range(1, 255));
+            } else if i == 255 {
+                assert!(!s.any_range(0, 254));
+            } else {
+                assert!(!s.any_range(0, i - 1));
+                assert!(!s.any_range(i + 1, 255));
+            }
+        }
+
+        let mut s = Set256::default();
+
+        s.set_range(20, 64);
+        assert!((0..=19).all(|i| !s.contains(i)));
+        assert!((20..=64).all(|i| s.contains(i)));
+        assert!((65..=255).all(|i| !s.contains(i)));
+        assert!(s.all_range(20, 64));
+        assert!(!s.any_range(0, 19));
+        assert!(!s.any_range(65, 255));
+
+        s.set_range(78, 127);
+        assert!((0..=19).all(|i| !s.contains(i)));
+        assert!((20..=64).all(|i| s.contains(i)));
+        assert!((65..=77).all(|i| !s.contains(i)));
+        assert!((78..=127).all(|i| s.contains(i)));
+        assert!((128..=255).all(|i| !s.contains(i)));
+        assert!(!s.any_range(0, 19));
+        assert!(s.all_range(20, 64));
+        assert!(!s.any_range(65, 77));
+        assert!(s.all_range(78, 127));
+        assert!(!s.any_range(128, 255));
+
+        s.set_range(190, 191);
+        assert!((0..=19).all(|i| !s.contains(i)));
+        assert!((20..=64).all(|i| s.contains(i)));
+        assert!((65..=77).all(|i| !s.contains(i)));
+        assert!((78..=127).all(|i| s.contains(i)));
+        assert!((128..=189).all(|i| !s.contains(i)));
+        assert!((190..=191).all(|i| s.contains(i)));
+        assert!((192..=255).all(|i| !s.contains(i)));
+        assert!(!s.any_range(0, 19));
+        assert!(s.all_range(20, 64));
+        assert!(!s.any_range(65, 77));
+        assert!(s.all_range(78, 127));
+        assert!(!s.any_range(128, 189));
+        assert!(s.all_range(190, 191));
+        assert!(!s.any_range(192, 255));
+
+        s.set_range(201, 201);
+        assert!((0..=19).all(|i| !s.contains(i)));
+        assert!((20..=64).all(|i| s.contains(i)));
+        assert!((65..=77).all(|i| !s.contains(i)));
+        assert!((78..=127).all(|i| s.contains(i)));
+        assert!((128..=189).all(|i| !s.contains(i)));
+        assert!((190..=191).all(|i| s.contains(i)));
+        assert!((192..=200).all(|i| !s.contains(i)));
+        assert!(s.contains(201));
+        assert!((202..=255).all(|i| !s.contains(i)));
+        assert!(!s.any_range(0, 19));
+        assert!(s.all_range(20, 64));
+        assert!(!s.any_range(65, 77));
+        assert!(s.all_range(78, 127));
+        assert!(!s.any_range(128, 189));
+        assert!(s.all_range(190, 191));
+        assert!(!s.any_range(192, 200));
+        assert!(s.all_range(201, 201));
+        assert!(!s.any_range(202, 255));
+
+        s.clear_range(30, 63);
+        assert!((0..=19).all(|i| !s.contains(i)));
+        assert!((20..30).all(|i| s.contains(i)));
+        assert!((30..=63).all(|i| !s.contains(i)));
+        assert!(s.contains(64));
+        assert!((65..=77).all(|i| !s.contains(i)));
+        assert!((78..=127).all(|i| s.contains(i)));
+        assert!((128..=189).all(|i| !s.contains(i)));
+        assert!((190..=191).all(|i| s.contains(i)));
+        assert!((192..=200).all(|i| !s.contains(i)));
+        assert!(s.contains(201));
+        assert!((202..=255).all(|i| !s.contains(i)));
+        assert!(!s.any_range(0, 19));
+        assert!(s.all_range(20, 29));
+        assert!(!s.any_range(30, 63));
+        assert!(s.all_range(64, 64));
+        assert!(!s.any_range(65, 77));
+        assert!(s.all_range(78, 127));
+        assert!(!s.any_range(128, 189));
+        assert!(s.all_range(190, 191));
+        assert!(!s.any_range(192, 200));
+        assert!(s.all_range(201, 201));
+        assert!(!s.any_range(202, 255));
+
+        s.clear_range(127, 130);
+        assert!((0..=19).all(|i| !s.contains(i)));
+        assert!((20..30).all(|i| s.contains(i)));
+        assert!((30..=63).all(|i| !s.contains(i)));
+        assert!(s.contains(64));
+        assert!((65..=77).all(|i| !s.contains(i)));
+        assert!((78..127).all(|i| s.contains(i)));
+        assert!((127..=189).all(|i| !s.contains(i)));
+        assert!((190..=191).all(|i| s.contains(i)));
+        assert!((192..=200).all(|i| !s.contains(i)));
+        assert!(s.contains(201));
+        assert!((202..=255).all(|i| !s.contains(i)));
+        assert!(!s.any_range(0, 19));
+        assert!(s.all_range(20, 29));
+        assert!(!s.any_range(30, 63));
+        assert!(s.all_range(64, 64));
+        assert!(!s.any_range(65, 77));
+        assert!(s.all_range(78, 126));
+        assert!(!s.any_range(127, 189));
+        assert!(s.all_range(190, 191));
+        assert!(!s.any_range(192, 200));
+        assert!(s.all_range(201, 201));
+        assert!(!s.any_range(202, 255));
+
+        s.clear_range(195, 230);
+        assert!((0..=19).all(|i| !s.contains(i)));
+        assert!((20..30).all(|i| s.contains(i)));
+        assert!((30..=63).all(|i| !s.contains(i)));
+        assert!(s.contains(64));
+        assert!((65..=77).all(|i| !s.contains(i)));
+        assert!((78..127).all(|i| s.contains(i)));
+        assert!((127..=189).all(|i| !s.contains(i)));
+        assert!((190..=191).all(|i| s.contains(i)));
+        assert!((192..=255).all(|i| !s.contains(i)));
+        assert!(!s.any_range(0, 19));
+        assert!(s.all_range(20, 29));
+        assert!(!s.any_range(30, 63));
+        assert!(s.all_range(64, 64));
+        assert!(!s.any_range(65, 77));
+        assert!(s.all_range(78, 126));
+        assert!(!s.any_range(127, 189));
+        assert!(s.all_range(190, 191));
+        assert!(!s.any_range(192, 255));
     }
 }


### PR DESCRIPTION
This speeds up unit tests a lot.