### PR TITLE
Rrefactor away curswant

### DIFF
--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -187,6 +187,7 @@ jobs:
           mkdir -p test/cases/bootstrapped
           OUTPUT_TEST_CASE=${{ matrix.vim.distr }}_${{ matrix.vim.version }}_${{ matrix.glue-lang }}.jieba_test_case
           echo "output_test_case=test/cases/bootstrapped/$OUTPUT_TEST_CASE" >> "$GITHUB_OUTPUT"
+          set +e
           case ${{ matrix.vim.distr }} in
             vim)
               jieba_vim_rs_metatest bootstrap \
@@ -203,6 +204,20 @@ jobs:
                 test/cases/bootstrap/*.jieba_test_case
               ;;
           esac
+          exit_code=$?
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          if [ $exit_code != 0 ]; then
+            false
+          endif
+      - name: Check bootstrap case verification exit code
+        shell: bash
+        run: |
+          code="${{ steps.run-bootstrap-case-verification.outputs.exit_code }}"
+          if [ "$code" != 0 ] && [ "$code" != 1 ]; then
+            echo "Bootstrap case verification may have panicked" >&2
+            false
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: bootstrapped-test-case-${{ matrix.vim.distr }}-${{ matrix.vim.version }}-${{ matrix.glue-lang }}

--- a/.github/workflows/ci2.yml
+++ b/.github/workflows/ci2.yml
@@ -209,7 +209,7 @@ jobs:
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           if [ $exit_code != 0 ]; then
             false
-          endif
+          fi
       - name: Check bootstrap case verification exit code
         shell: bash
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: cargo-check
         name: cargo clippy check (rust_backend)
-        entry: cargo clippy --all-targets --workspace --manifest-path rust_backend/Cargo.toml
+        entry: cargo clippy --workspace --manifest-path rust_backend/Cargo.toml
         language: system
         always_run: true
         pass_filenames: false

--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -149,7 +149,7 @@ function! JiebaNmap(motion, count, model_funcname)
     else
         let l:result_dict = JiebaModelNmap(a:motion, getcurpos(), a:count)
     endif
-    call setpos(".", l:result_dict["cursor"])
+    call cursor(l:result_dict["cursor"][1:2])
 endfunction
 
 function! JiebaXmap(motion, count, model_funcname)
@@ -180,13 +180,13 @@ function! JiebaOmap(motion, repeat, count, operator, register, model_funcname)
     else
         let l:result_dict = JiebaModelOmap(a:motion, l:orig_curpos, a:count, a:operator)
     endif
-    call setpos(".", l:result_dict["langle"])
+    call cursor(l:result_dict["langle"][1:2])
     " This no-op line effectively sets an undoable checkpoint such that |u|
     " undos all operations up to this line.
     call setline(".", getline("."))
     if l:result_dict["prevent_change"]
         " Land the cursor to potentially a new position.
-        call setpos(".", l:result_dict["cursor"])
+        call cursor(l:result_dict["cursor"][1:2])
     else
         " We need to use '< and '> marks in this function. Thus the clutters
         " here.
@@ -244,7 +244,7 @@ function! JiebaOmap(motion, repeat, count, operator, register, model_funcname)
         endif
 
         " Land the cursor to potentially a new position.
-        call setpos(".", l:result_dict["cursor"])
+        call cursor(l:result_dict["cursor"][1:2])
 
         " Special treatment of d-special in nvim.
         if has("nvim") && a:operator ==# "d" && l:result_dict["visualmode"] ==# "V"

--- a/rust_backend/Cargo.lock
+++ b/rust_backend/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "jieba_vim_rs_metatest"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "camino",

--- a/rust_backend/Cargo.lock
+++ b/rust_backend/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "jieba_vim_rs_metatest"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "camino",

--- a/rust_backend/Cargo.lock
+++ b/rust_backend/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "jieba_vim_rs_metatest"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "camino",

--- a/rust_backend/jieba_vim_rs_core/src/motion/nmap_w.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/nmap_w.rs
@@ -97,7 +97,7 @@ impl<C: JiebaPlaceholder> WordMotion<C> {
             b"1"
         };
         Ok(NmapOutput {
-            cursor: [bufnum, lnum, col_p1, off, col_p1],
+            cursor: [bufnum, lnum, col_p1, off],
             prevent_change,
         })
     }

--- a/rust_backend/jieba_vim_rs_core/src/motion/word_motion.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/word_motion.rs
@@ -20,7 +20,7 @@ pub struct WordMotion<C> {
 }
 
 pub struct NmapOutput {
-    pub cursor: CursorPositionCurswant,
+    pub cursor: Position,
     pub prevent_change: &'static [u8],
 }
 
@@ -32,7 +32,7 @@ pub struct XmapOutput<'a> {
 }
 
 pub struct OmapOutput {
-    pub cursor: CursorPositionCurswant,
+    pub cursor: Position,
     pub langle: Position,
     pub rangle: Position,
     pub visualmode: &'static [u8],
@@ -81,7 +81,7 @@ impl<C: JiebaPlaceholder> WordMotion<C> {
             _ => unreachable!("invalid motion key sequence: {:?}", motion),
         };
         Ok(NmapOutput {
-            cursor: [0, lnum, col_m1 + 1, 0, col_m1 + 1],
+            cursor: [0, lnum, col_m1 + 1, 0],
             prevent_change: b"0",
         })
     }
@@ -216,7 +216,7 @@ impl<C: JiebaPlaceholder> WordMotion<C> {
         };
         let prevent_change = if output.prevent_change { b"1" } else { b"0" };
         Ok(OmapOutput {
-            cursor: [0, next_lnum, next_col_m1 + 1, 0, next_col_m1 + 1],
+            cursor: [0, next_lnum, next_col_m1 + 1, 0],
             langle: [0, langle_lnum, langle_col_m1 + 1, 0],
             rangle: [0, rangle_lnum, rangle_col_m1 + 1, 0],
             visualmode: b"v",

--- a/rust_backend/jieba_vim_rs_core/tests/nvim_v0_10_2_py311.rs
+++ b/rust_backend/jieba_vim_rs_core/tests/nvim_v0_10_2_py311.rs
@@ -8,7 +8,7 @@ use jieba_vim_rs_core::token::Tokenizer;
 use keyword_cutter::KeywordCutter;
 
 #[test]
-fn test_d348f112e252ae7c657f3b6a6291cc7d7581295e48b56307d2406092() {
+fn test_a8d4f7746427a144e38ca1ec7bee2a21d86ab52b7c2f8e1acb26075e() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -31,7 +31,7 @@ fn test_d348f112e252ae7c657f3b6a6291cc7d7581295e48b56307d2406092() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize, 6usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -39,7 +39,7 @@ fn test_d348f112e252ae7c657f3b6a6291cc7d7581295e48b56307d2406092() {
 }
 
 #[test]
-fn test_698e57d0555d71c2d35a6b462c2af57b8ff017a14aff967cf1c3afbe() {
+fn test_c49507d01cdbea465d32314ceb801d9c8f254abc9c6f69815f182df8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -53,11 +53,11 @@ fn test_698e57d0555d71c2d35a6b462c2af57b8ff017a14aff967cf1c3afbe() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_706d85f12b47c3d525af804374cbc7e241aa86cc95e22e64264096ba() {
+fn test_8cce72cc00faa068725a1fe04b88053850a3f2000273e4f4730c6053() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -71,11 +71,11 @@ fn test_706d85f12b47c3d525af804374cbc7e241aa86cc95e22e64264096ba() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_80079981ca7ca6dd775d356f8d924c607deffc768fa0018f8b12be2a() {
+fn test_03a125e3f6590812f466d308ddc74afb24d01987a305b40f4eb8d9b1() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -89,11 +89,11 @@ fn test_80079981ca7ca6dd775d356f8d924c607deffc768fa0018f8b12be2a() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_8296af34e1f15c6444a53271d4d5f75a7eae56f85b851e01798dca1f() {
+fn test_10b646de08ba83ad3a6d33fabcde1c1c5fadc694e8d3a5b4088a3744() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -107,11 +107,11 @@ fn test_8296af34e1f15c6444a53271d4d5f75a7eae56f85b851e01798dca1f() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_797f49bf8ea25f1bafdb3b8d59477ea2447dfbbd137facedb78198ce() {
+fn test_3a6b4a36a2338d2844f0df72ced159c538450f9783bb8b3e0cf9e472() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -125,11 +125,11 @@ fn test_797f49bf8ea25f1bafdb3b8d59477ea2447dfbbd137facedb78198ce() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_7015f41f9bfabaa3bfc6ae2697658484cfee45d53c4341f34edc0f10() {
+fn test_329b00bed6a566f63230dff020b2d3c73b5123e211812ddd9f57429b() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -143,11 +143,11 @@ fn test_7015f41f9bfabaa3bfc6ae2697658484cfee45d53c4341f34edc0f10() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_c209f30411450c7334ad40b70090d535cb0fa726ee00a3773550a0c5() {
+fn test_f09570f84730fa18dae7fff574e9d718d9fde747f5cc3fe797069d47() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -161,11 +161,11 @@ fn test_c209f30411450c7334ad40b70090d535cb0fa726ee00a3773550a0c5() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_202e4390a90c3411730e2a0c0d8c6684d00266d1e0231de11107d539() {
+fn test_4ab46fe2887d1522e96230eccb0894f4adb901a241a5b428612d9b14() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -179,11 +179,11 @@ fn test_202e4390a90c3411730e2a0c0d8c6684d00266d1e0231de11107d539() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_52135bf88ac6b5780b7c45bce3e75aceaff381984bad60d4a07aa516() {
+fn test_cf51bdeb6cae4ca1d663f0040b03ef23d3364c5f1a5bdb63f7be2b23() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -197,11 +197,11 @@ fn test_52135bf88ac6b5780b7c45bce3e75aceaff381984bad60d4a07aa516() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_4c0437ad690881933de761f489767067a0c46e5ae6e6d26e49d4d92c() {
+fn test_2e06b3142444ec8d799820b31e62d6d33c60e501e69922c682043f13() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -215,11 +215,11 @@ fn test_4c0437ad690881933de761f489767067a0c46e5ae6e6d26e49d4d92c() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_4122b22abea40181a71e20fd6f0f4fe698b0eb1b43ed678e8cfe19bb() {
+fn test_a23235e47791c4c2df0c9b13493a3c9832e4caa21cede2dba0b86cd9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -233,11 +233,11 @@ fn test_4122b22abea40181a71e20fd6f0f4fe698b0eb1b43ed678e8cfe19bb() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_1e77aa1259b352d0424c4810c2c06e8210f88200edad7cd574f28425() {
+fn test_38600c9b3ad5e0e4ddb5625882bf02c84436780f9a6296e16b2a1de3() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -251,11 +251,11 @@ fn test_1e77aa1259b352d0424c4810c2c06e8210f88200edad7cd574f28425() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_46f6b57c58a49bc312b67f455da23cf0bcfb9a5b869466586a9a05d0() {
+fn test_be520fc284952bcd9583f04fa1c63ad706c032517f4df840518cdffc() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -269,11 +269,11 @@ fn test_46f6b57c58a49bc312b67f455da23cf0bcfb9a5b869466586a9a05d0() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_d7dd1d63585a4759bdcf74ac3497bf8383aac9be662bf228f908342e() {
+fn test_a96daab181124c5a19a423777f5aee4ce188f1c837f5b4ee5c9ca04a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -287,11 +287,11 @@ fn test_d7dd1d63585a4759bdcf74ac3497bf8383aac9be662bf228f908342e() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_b84918bb3e786c4d846a9e78e010500fea8f291803b6bda22850955b() {
+fn test_69aeb41ce405f3b2dcdc586ea6e1aaffcf3630053e14b5bc9fccc7de() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -305,11 +305,11 @@ fn test_b84918bb3e786c4d846a9e78e010500fea8f291803b6bda22850955b() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_6c6aa33a9bc7195ba3f736ebd073cc9fb0106e09465b343f773279b3() {
+fn test_1820a6b27c57b06f594755069925c9ac174c225dc6b6d9bc02161bb6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -323,7 +323,7 @@ fn test_6c6aa33a9bc7195ba3f736ebd073cc9fb0106e09465b343f773279b3() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
@@ -855,7 +855,7 @@ fn test_179910635d6c8841031d9b99aa239b76bf7dda8c81732a7f46b42e02() {
 }
 
 #[test]
-fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
+fn test_8fb704e4f7569d63dbd32678f9b83a8481299a11154abcbbcd207451() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -870,7 +870,7 @@ fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -878,7 +878,7 @@ fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
 }
 
 #[test]
-fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
+fn test_44a6e532bc15add989567d8b6eda27343830dcb2c32fd2bcc60bf065() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -893,7 +893,7 @@ fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -901,7 +901,7 @@ fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
 }
 
 #[test]
-fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
+fn test_c7d2120a5a8abb067dc68f04172115594efb14ab0f3dfb6862dfa154() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -917,7 +917,7 @@ fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 3usize, 0usize, 3usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 5usize, 0usize]);
@@ -3634,7 +3634,7 @@ fn test_750edd71d543211b4135450d760ce7d21c0d170c1f7d7020707100da() {
 }
 
 #[test]
-fn test_ce8febe9df4a357be1b3bd79b05133b26b21bb47bafcc820ebca2b51() {
+fn test_95649317eb585c559ad8386aaac4ae2a7f8a3856426550d028b130a6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3648,12 +3648,12 @@ fn test_ce8febe9df4a357be1b3bd79b05133b26b21bb47bafcc820ebca2b51() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_3d2f8c4d5c2018fe7c244fe3c59f7e9b615f1025ce13c7f94c665250() {
+fn test_3b4ae9f1b528d423ae8963133cef63321538d01ad34a1caa4ebe03f9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3668,7 +3668,7 @@ fn test_3d2f8c4d5c2018fe7c244fe3c59f7e9b615f1025ce13c7f94c665250() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3676,7 +3676,7 @@ fn test_3d2f8c4d5c2018fe7c244fe3c59f7e9b615f1025ce13c7f94c665250() {
 }
 
 #[test]
-fn test_fb5e235846ebb5408fc87eb56231a559d8577cafd0b38b44029b0b19() {
+fn test_5c75393b2ef4045dd42efa365a1f171b50cfbc538e13d0204fbd9eb6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3691,7 +3691,7 @@ fn test_fb5e235846ebb5408fc87eb56231a559d8577cafd0b38b44029b0b19() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3699,7 +3699,7 @@ fn test_fb5e235846ebb5408fc87eb56231a559d8577cafd0b38b44029b0b19() {
 }
 
 #[test]
-fn test_1395313c1f2471b89b1d89ff154168bf5e4af6b574b8f0de1cd3ae40() {
+fn test_64d71eea8eab213bb976f1d989309f66bf5a5b61372236a53498a927() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3714,7 +3714,7 @@ fn test_1395313c1f2471b89b1d89ff154168bf5e4af6b574b8f0de1cd3ae40() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3722,7 +3722,7 @@ fn test_1395313c1f2471b89b1d89ff154168bf5e4af6b574b8f0de1cd3ae40() {
 }
 
 #[test]
-fn test_bc170f091cd4dd908bdff4fe12c0765083375e143f8cad24e53cf85e() {
+fn test_45950b9735f1c99d92a1ebfca666fe2c1456eec12bc0178056f38391() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3737,7 +3737,7 @@ fn test_bc170f091cd4dd908bdff4fe12c0765083375e143f8cad24e53cf85e() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3745,7 +3745,7 @@ fn test_bc170f091cd4dd908bdff4fe12c0765083375e143f8cad24e53cf85e() {
 }
 
 #[test]
-fn test_5d3794892614cde77fc5d5d3953b37bfce5cacf46019472f29ea95c5() {
+fn test_b4b63b3556cd1fa007f4ec709bd4d9de6a22471caa7edc91b6305da8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3759,12 +3759,12 @@ fn test_5d3794892614cde77fc5d5d3953b37bfce5cacf46019472f29ea95c5() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_fb557ac4f6aab70b0a7c4cba817420bf042c4987c8715d577848d41d() {
+fn test_5494fee08eea7981eee7de1f67198e3f7dd34c81d5756418433ad7a4() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3779,7 +3779,7 @@ fn test_fb557ac4f6aab70b0a7c4cba817420bf042c4987c8715d577848d41d() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3787,7 +3787,7 @@ fn test_fb557ac4f6aab70b0a7c4cba817420bf042c4987c8715d577848d41d() {
 }
 
 #[test]
-fn test_73f62b80718f82a3f388dff5339f302d78f66b53e38ec8e6c1b8ec40() {
+fn test_55ad8aa61160176b4777ae5ba53985090add0da68f85c37bc320dd9f() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3802,7 +3802,7 @@ fn test_73f62b80718f82a3f388dff5339f302d78f66b53e38ec8e6c1b8ec40() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3810,7 +3810,7 @@ fn test_73f62b80718f82a3f388dff5339f302d78f66b53e38ec8e6c1b8ec40() {
 }
 
 #[test]
-fn test_962474a8d396fc7d0f37d9f3c1a761687107f50f9d3b606e4071d801() {
+fn test_a2ca5aaedc620f7b00a0383f2ecc6657eda3014407cb1c5ae66fbddf() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3825,7 +3825,7 @@ fn test_962474a8d396fc7d0f37d9f3c1a761687107f50f9d3b606e4071d801() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3833,7 +3833,7 @@ fn test_962474a8d396fc7d0f37d9f3c1a761687107f50f9d3b606e4071d801() {
 }
 
 #[test]
-fn test_c99659991170cc57a618f937988c9f82b25b3cdd0988ccad71e51c09() {
+fn test_83ccdbbf9807dd1480983d040b2b81bc07068b06d477f02b703d8955() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3848,7 +3848,7 @@ fn test_c99659991170cc57a618f937988c9f82b25b3cdd0988ccad71e51c09() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3856,7 +3856,7 @@ fn test_c99659991170cc57a618f937988c9f82b25b3cdd0988ccad71e51c09() {
 }
 
 #[test]
-fn test_f4e52c2049b86b05e8914bac7687beb9510e553c0b3aec0d506c69e3() {
+fn test_1232e5a959fa58b32d1b0e6b147f5739e332b5c0499e21f0dbb93968() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3871,12 +3871,12 @@ fn test_f4e52c2049b86b05e8914bac7687beb9510e553c0b3aec0d506c69e3() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_bfc5e22ca2d291d5c13f4c87eaa8a5356eba837828f3d6abc009c2fb() {
+fn test_52f5873e79e7244d97482854e3f55bd55d64db39a8bf767342de3d4b() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3892,7 +3892,7 @@ fn test_bfc5e22ca2d291d5c13f4c87eaa8a5356eba837828f3d6abc009c2fb() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -3900,7 +3900,7 @@ fn test_bfc5e22ca2d291d5c13f4c87eaa8a5356eba837828f3d6abc009c2fb() {
 }
 
 #[test]
-fn test_1a76649c6f7df4b7b26b414ca2648fb2784ebd38917337d49d03cae7() {
+fn test_80e808659787dcdaebcc66e723bae56eec6cd5f7e052433e20c3c5a3() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3916,7 +3916,7 @@ fn test_1a76649c6f7df4b7b26b414ca2648fb2784ebd38917337d49d03cae7() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -3924,7 +3924,7 @@ fn test_1a76649c6f7df4b7b26b414ca2648fb2784ebd38917337d49d03cae7() {
 }
 
 #[test]
-fn test_693a30ae021128704e357b41fa452acafdd043a8b0f8a5ed11833dcf() {
+fn test_3ac4e49b96f591c64f5f678bf0c5c3bf1f85f3c45fc17e50d1f7c99a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3940,7 +3940,7 @@ fn test_693a30ae021128704e357b41fa452acafdd043a8b0f8a5ed11833dcf() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -3948,7 +3948,7 @@ fn test_693a30ae021128704e357b41fa452acafdd043a8b0f8a5ed11833dcf() {
 }
 
 #[test]
-fn test_108e60bf8c518e15aec760e5ded985626e3766b50d0e3e02def73d29() {
+fn test_097f3b52c20d23b90bbaa0eca9476caf1ef80325bb3895a43b64cb59() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3964,7 +3964,7 @@ fn test_108e60bf8c518e15aec760e5ded985626e3766b50d0e3e02def73d29() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -3972,7 +3972,7 @@ fn test_108e60bf8c518e15aec760e5ded985626e3766b50d0e3e02def73d29() {
 }
 
 #[test]
-fn test_d79f0c071d66d4a46182372ff56e55951199f31006f623230237d567() {
+fn test_52bc5c52d1d29e812e20697130033c6e6bd1afc573a78ea85d61d790() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3987,12 +3987,12 @@ fn test_d79f0c071d66d4a46182372ff56e55951199f31006f623230237d567() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_4bd15592fedf02f774998db6dfbc9e92bdb54d669d9722bf60f3ae05() {
+fn test_b390ceadac601ac21217a9e177a8c69067428d82d1f32c8ad7013fa8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4008,7 +4008,7 @@ fn test_4bd15592fedf02f774998db6dfbc9e92bdb54d669d9722bf60f3ae05() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4016,7 +4016,7 @@ fn test_4bd15592fedf02f774998db6dfbc9e92bdb54d669d9722bf60f3ae05() {
 }
 
 #[test]
-fn test_9dbb05856bcba0b5e92f5c1a2c29892a86e3b986aa15b8a0bb5e7ade() {
+fn test_829b2d40486beb222742cf61169e947ba33048a0d03beb0a08fced05() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4032,7 +4032,7 @@ fn test_9dbb05856bcba0b5e92f5c1a2c29892a86e3b986aa15b8a0bb5e7ade() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4040,7 +4040,7 @@ fn test_9dbb05856bcba0b5e92f5c1a2c29892a86e3b986aa15b8a0bb5e7ade() {
 }
 
 #[test]
-fn test_581cf81573afa927a815f8b92b6cc55d761635b928828594830f94db() {
+fn test_df4bd5abac9651056fae31ce8cd90c6b3e3bdf06f10e957aff4f5b43() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4056,7 +4056,7 @@ fn test_581cf81573afa927a815f8b92b6cc55d761635b928828594830f94db() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4064,7 +4064,7 @@ fn test_581cf81573afa927a815f8b92b6cc55d761635b928828594830f94db() {
 }
 
 #[test]
-fn test_5500337756cdfcb86b417f834d9c7e52267e5f810076199bf7541366() {
+fn test_df72ec8230b00071f43a797c51c6081c23cdc2ceed79baab5405016f() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4080,7 +4080,7 @@ fn test_5500337756cdfcb86b417f834d9c7e52267e5f810076199bf7541366() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4088,7 +4088,7 @@ fn test_5500337756cdfcb86b417f834d9c7e52267e5f810076199bf7541366() {
 }
 
 #[test]
-fn test_be3ab94b7c9794c8ce63979fc3dc0fc519704fc29522c104fa1061db() {
+fn test_225462ea5425878e213d72cb77ef39859acf053bd1b5803057f2bed8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4103,6 +4103,379 @@ fn test_be3ab94b7c9794c8ce63979fc3dc0fc519704fc29522c104fa1061db() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+}
+
+#[test]
+fn test_061da9c720104ca623958ae278fc286b8b29cfa7d44048fce15b7a30() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_d1214951e79590bf246f9ccd4efe5b35168f270d44f7424b6a6776e5() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_c5edf4253c0d257865d5b9f791117a697794950a5749b6abc1e2f65f() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_3626fd483a120b9212e2f477d573660874b8ee374640138613f53c6e() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_34786789639d2832beddaa52041f9f9beab2c1bab2e463cc1066b31a() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[49u8,][..]);
+}
+
+#[test]
+fn test_98adcbc49b54bf9b8c1c57342c6f2ed405f8bd049d6565d6c1909fc0() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_30209a5be2983ce24d3a865fc6a1e672079d3c10a08b771b91ef3b08() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_58138e08422217b5f1add492866f46a4b092bb9307a6741c0a27baa2() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_d5755cc95aa591c3c2b4364d8b57089a2deba1dc718b19db5f1866bc() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_5ddb9c34aef49344827ab1f543b72ff291b70c0852ae96c8f4d60025() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[49u8,][..]);
+}
+
+#[test]
+fn test_fa205b7f7bae5c6b292c7242e9974a48c179228356d551449cafdb3c() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_fa4d59fbef8c9fcb4f254e83c9407a1409512734808d2f460175485e() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_c8fef4f0ae8b45e944fa64d6c664b325c557f059737750f541733947() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_25ddd8699f5d7467ffde4c6e8b10c03963eaf6f902db9e4c3cd569c3() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_29fb98e8f4b9e8132988a71a4e26432ea130d3dc95e34b1fed5436c5() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[std::str::from_utf8(
+                &[
+                    97u8, 98u8, 99u8, 32u8, 32u8, 32u8, 32u8, 100u8, 101u8,
+                    102u8,
+                ][..],
+            )
+            .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 1usize, 0usize, 1usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 8usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }

--- a/rust_backend/jieba_vim_rs_core/tests/nvim_v0_11_5_py311.rs
+++ b/rust_backend/jieba_vim_rs_core/tests/nvim_v0_11_5_py311.rs
@@ -8,7 +8,7 @@ use jieba_vim_rs_core::token::Tokenizer;
 use keyword_cutter::KeywordCutter;
 
 #[test]
-fn test_d348f112e252ae7c657f3b6a6291cc7d7581295e48b56307d2406092() {
+fn test_a8d4f7746427a144e38ca1ec7bee2a21d86ab52b7c2f8e1acb26075e() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -31,7 +31,7 @@ fn test_d348f112e252ae7c657f3b6a6291cc7d7581295e48b56307d2406092() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize, 6usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -39,7 +39,7 @@ fn test_d348f112e252ae7c657f3b6a6291cc7d7581295e48b56307d2406092() {
 }
 
 #[test]
-fn test_698e57d0555d71c2d35a6b462c2af57b8ff017a14aff967cf1c3afbe() {
+fn test_c49507d01cdbea465d32314ceb801d9c8f254abc9c6f69815f182df8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -53,11 +53,11 @@ fn test_698e57d0555d71c2d35a6b462c2af57b8ff017a14aff967cf1c3afbe() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_706d85f12b47c3d525af804374cbc7e241aa86cc95e22e64264096ba() {
+fn test_8cce72cc00faa068725a1fe04b88053850a3f2000273e4f4730c6053() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -71,11 +71,11 @@ fn test_706d85f12b47c3d525af804374cbc7e241aa86cc95e22e64264096ba() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_80079981ca7ca6dd775d356f8d924c607deffc768fa0018f8b12be2a() {
+fn test_03a125e3f6590812f466d308ddc74afb24d01987a305b40f4eb8d9b1() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -89,11 +89,11 @@ fn test_80079981ca7ca6dd775d356f8d924c607deffc768fa0018f8b12be2a() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_8296af34e1f15c6444a53271d4d5f75a7eae56f85b851e01798dca1f() {
+fn test_10b646de08ba83ad3a6d33fabcde1c1c5fadc694e8d3a5b4088a3744() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -107,11 +107,11 @@ fn test_8296af34e1f15c6444a53271d4d5f75a7eae56f85b851e01798dca1f() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_797f49bf8ea25f1bafdb3b8d59477ea2447dfbbd137facedb78198ce() {
+fn test_3a6b4a36a2338d2844f0df72ced159c538450f9783bb8b3e0cf9e472() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -125,11 +125,11 @@ fn test_797f49bf8ea25f1bafdb3b8d59477ea2447dfbbd137facedb78198ce() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_7015f41f9bfabaa3bfc6ae2697658484cfee45d53c4341f34edc0f10() {
+fn test_329b00bed6a566f63230dff020b2d3c73b5123e211812ddd9f57429b() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -143,11 +143,11 @@ fn test_7015f41f9bfabaa3bfc6ae2697658484cfee45d53c4341f34edc0f10() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_c209f30411450c7334ad40b70090d535cb0fa726ee00a3773550a0c5() {
+fn test_f09570f84730fa18dae7fff574e9d718d9fde747f5cc3fe797069d47() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -161,11 +161,11 @@ fn test_c209f30411450c7334ad40b70090d535cb0fa726ee00a3773550a0c5() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_202e4390a90c3411730e2a0c0d8c6684d00266d1e0231de11107d539() {
+fn test_4ab46fe2887d1522e96230eccb0894f4adb901a241a5b428612d9b14() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -179,11 +179,11 @@ fn test_202e4390a90c3411730e2a0c0d8c6684d00266d1e0231de11107d539() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_52135bf88ac6b5780b7c45bce3e75aceaff381984bad60d4a07aa516() {
+fn test_cf51bdeb6cae4ca1d663f0040b03ef23d3364c5f1a5bdb63f7be2b23() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -197,11 +197,11 @@ fn test_52135bf88ac6b5780b7c45bce3e75aceaff381984bad60d4a07aa516() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_4c0437ad690881933de761f489767067a0c46e5ae6e6d26e49d4d92c() {
+fn test_2e06b3142444ec8d799820b31e62d6d33c60e501e69922c682043f13() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -215,11 +215,11 @@ fn test_4c0437ad690881933de761f489767067a0c46e5ae6e6d26e49d4d92c() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_4122b22abea40181a71e20fd6f0f4fe698b0eb1b43ed678e8cfe19bb() {
+fn test_a23235e47791c4c2df0c9b13493a3c9832e4caa21cede2dba0b86cd9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -233,11 +233,11 @@ fn test_4122b22abea40181a71e20fd6f0f4fe698b0eb1b43ed678e8cfe19bb() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_1e77aa1259b352d0424c4810c2c06e8210f88200edad7cd574f28425() {
+fn test_38600c9b3ad5e0e4ddb5625882bf02c84436780f9a6296e16b2a1de3() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -251,11 +251,11 @@ fn test_1e77aa1259b352d0424c4810c2c06e8210f88200edad7cd574f28425() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_46f6b57c58a49bc312b67f455da23cf0bcfb9a5b869466586a9a05d0() {
+fn test_be520fc284952bcd9583f04fa1c63ad706c032517f4df840518cdffc() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -269,11 +269,11 @@ fn test_46f6b57c58a49bc312b67f455da23cf0bcfb9a5b869466586a9a05d0() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_d7dd1d63585a4759bdcf74ac3497bf8383aac9be662bf228f908342e() {
+fn test_a96daab181124c5a19a423777f5aee4ce188f1c837f5b4ee5c9ca04a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -287,11 +287,11 @@ fn test_d7dd1d63585a4759bdcf74ac3497bf8383aac9be662bf228f908342e() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_b84918bb3e786c4d846a9e78e010500fea8f291803b6bda22850955b() {
+fn test_69aeb41ce405f3b2dcdc586ea6e1aaffcf3630053e14b5bc9fccc7de() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -305,11 +305,11 @@ fn test_b84918bb3e786c4d846a9e78e010500fea8f291803b6bda22850955b() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_6c6aa33a9bc7195ba3f736ebd073cc9fb0106e09465b343f773279b3() {
+fn test_1820a6b27c57b06f594755069925c9ac174c225dc6b6d9bc02161bb6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -323,7 +323,7 @@ fn test_6c6aa33a9bc7195ba3f736ebd073cc9fb0106e09465b343f773279b3() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
@@ -855,7 +855,7 @@ fn test_179910635d6c8841031d9b99aa239b76bf7dda8c81732a7f46b42e02() {
 }
 
 #[test]
-fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
+fn test_8fb704e4f7569d63dbd32678f9b83a8481299a11154abcbbcd207451() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -870,7 +870,7 @@ fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -878,7 +878,7 @@ fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
 }
 
 #[test]
-fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
+fn test_44a6e532bc15add989567d8b6eda27343830dcb2c32fd2bcc60bf065() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -893,7 +893,7 @@ fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -901,7 +901,7 @@ fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
 }
 
 #[test]
-fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
+fn test_c7d2120a5a8abb067dc68f04172115594efb14ab0f3dfb6862dfa154() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -917,7 +917,7 @@ fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 3usize, 0usize, 3usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 5usize, 0usize]);
@@ -3634,7 +3634,7 @@ fn test_750edd71d543211b4135450d760ce7d21c0d170c1f7d7020707100da() {
 }
 
 #[test]
-fn test_ce8febe9df4a357be1b3bd79b05133b26b21bb47bafcc820ebca2b51() {
+fn test_95649317eb585c559ad8386aaac4ae2a7f8a3856426550d028b130a6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3648,12 +3648,12 @@ fn test_ce8febe9df4a357be1b3bd79b05133b26b21bb47bafcc820ebca2b51() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_3d2f8c4d5c2018fe7c244fe3c59f7e9b615f1025ce13c7f94c665250() {
+fn test_3b4ae9f1b528d423ae8963133cef63321538d01ad34a1caa4ebe03f9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3668,7 +3668,7 @@ fn test_3d2f8c4d5c2018fe7c244fe3c59f7e9b615f1025ce13c7f94c665250() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3676,7 +3676,7 @@ fn test_3d2f8c4d5c2018fe7c244fe3c59f7e9b615f1025ce13c7f94c665250() {
 }
 
 #[test]
-fn test_fb5e235846ebb5408fc87eb56231a559d8577cafd0b38b44029b0b19() {
+fn test_5c75393b2ef4045dd42efa365a1f171b50cfbc538e13d0204fbd9eb6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3691,7 +3691,7 @@ fn test_fb5e235846ebb5408fc87eb56231a559d8577cafd0b38b44029b0b19() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3699,7 +3699,7 @@ fn test_fb5e235846ebb5408fc87eb56231a559d8577cafd0b38b44029b0b19() {
 }
 
 #[test]
-fn test_1395313c1f2471b89b1d89ff154168bf5e4af6b574b8f0de1cd3ae40() {
+fn test_64d71eea8eab213bb976f1d989309f66bf5a5b61372236a53498a927() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3714,7 +3714,7 @@ fn test_1395313c1f2471b89b1d89ff154168bf5e4af6b574b8f0de1cd3ae40() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3722,7 +3722,7 @@ fn test_1395313c1f2471b89b1d89ff154168bf5e4af6b574b8f0de1cd3ae40() {
 }
 
 #[test]
-fn test_bc170f091cd4dd908bdff4fe12c0765083375e143f8cad24e53cf85e() {
+fn test_45950b9735f1c99d92a1ebfca666fe2c1456eec12bc0178056f38391() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3737,7 +3737,7 @@ fn test_bc170f091cd4dd908bdff4fe12c0765083375e143f8cad24e53cf85e() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3745,7 +3745,7 @@ fn test_bc170f091cd4dd908bdff4fe12c0765083375e143f8cad24e53cf85e() {
 }
 
 #[test]
-fn test_5d3794892614cde77fc5d5d3953b37bfce5cacf46019472f29ea95c5() {
+fn test_b4b63b3556cd1fa007f4ec709bd4d9de6a22471caa7edc91b6305da8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3759,12 +3759,12 @@ fn test_5d3794892614cde77fc5d5d3953b37bfce5cacf46019472f29ea95c5() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_fb557ac4f6aab70b0a7c4cba817420bf042c4987c8715d577848d41d() {
+fn test_5494fee08eea7981eee7de1f67198e3f7dd34c81d5756418433ad7a4() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3779,7 +3779,7 @@ fn test_fb557ac4f6aab70b0a7c4cba817420bf042c4987c8715d577848d41d() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3787,7 +3787,7 @@ fn test_fb557ac4f6aab70b0a7c4cba817420bf042c4987c8715d577848d41d() {
 }
 
 #[test]
-fn test_73f62b80718f82a3f388dff5339f302d78f66b53e38ec8e6c1b8ec40() {
+fn test_55ad8aa61160176b4777ae5ba53985090add0da68f85c37bc320dd9f() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3802,7 +3802,7 @@ fn test_73f62b80718f82a3f388dff5339f302d78f66b53e38ec8e6c1b8ec40() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3810,7 +3810,7 @@ fn test_73f62b80718f82a3f388dff5339f302d78f66b53e38ec8e6c1b8ec40() {
 }
 
 #[test]
-fn test_962474a8d396fc7d0f37d9f3c1a761687107f50f9d3b606e4071d801() {
+fn test_a2ca5aaedc620f7b00a0383f2ecc6657eda3014407cb1c5ae66fbddf() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3825,7 +3825,7 @@ fn test_962474a8d396fc7d0f37d9f3c1a761687107f50f9d3b606e4071d801() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3833,7 +3833,7 @@ fn test_962474a8d396fc7d0f37d9f3c1a761687107f50f9d3b606e4071d801() {
 }
 
 #[test]
-fn test_c99659991170cc57a618f937988c9f82b25b3cdd0988ccad71e51c09() {
+fn test_83ccdbbf9807dd1480983d040b2b81bc07068b06d477f02b703d8955() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3848,7 +3848,7 @@ fn test_c99659991170cc57a618f937988c9f82b25b3cdd0988ccad71e51c09() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -3856,7 +3856,7 @@ fn test_c99659991170cc57a618f937988c9f82b25b3cdd0988ccad71e51c09() {
 }
 
 #[test]
-fn test_f4e52c2049b86b05e8914bac7687beb9510e553c0b3aec0d506c69e3() {
+fn test_1232e5a959fa58b32d1b0e6b147f5739e332b5c0499e21f0dbb93968() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3871,12 +3871,12 @@ fn test_f4e52c2049b86b05e8914bac7687beb9510e553c0b3aec0d506c69e3() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_bfc5e22ca2d291d5c13f4c87eaa8a5356eba837828f3d6abc009c2fb() {
+fn test_52f5873e79e7244d97482854e3f55bd55d64db39a8bf767342de3d4b() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3892,7 +3892,7 @@ fn test_bfc5e22ca2d291d5c13f4c87eaa8a5356eba837828f3d6abc009c2fb() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -3900,7 +3900,7 @@ fn test_bfc5e22ca2d291d5c13f4c87eaa8a5356eba837828f3d6abc009c2fb() {
 }
 
 #[test]
-fn test_1a76649c6f7df4b7b26b414ca2648fb2784ebd38917337d49d03cae7() {
+fn test_80e808659787dcdaebcc66e723bae56eec6cd5f7e052433e20c3c5a3() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3916,7 +3916,7 @@ fn test_1a76649c6f7df4b7b26b414ca2648fb2784ebd38917337d49d03cae7() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -3924,7 +3924,7 @@ fn test_1a76649c6f7df4b7b26b414ca2648fb2784ebd38917337d49d03cae7() {
 }
 
 #[test]
-fn test_693a30ae021128704e357b41fa452acafdd043a8b0f8a5ed11833dcf() {
+fn test_3ac4e49b96f591c64f5f678bf0c5c3bf1f85f3c45fc17e50d1f7c99a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3940,7 +3940,7 @@ fn test_693a30ae021128704e357b41fa452acafdd043a8b0f8a5ed11833dcf() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -3948,7 +3948,7 @@ fn test_693a30ae021128704e357b41fa452acafdd043a8b0f8a5ed11833dcf() {
 }
 
 #[test]
-fn test_108e60bf8c518e15aec760e5ded985626e3766b50d0e3e02def73d29() {
+fn test_097f3b52c20d23b90bbaa0eca9476caf1ef80325bb3895a43b64cb59() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3964,7 +3964,7 @@ fn test_108e60bf8c518e15aec760e5ded985626e3766b50d0e3e02def73d29() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -3972,7 +3972,7 @@ fn test_108e60bf8c518e15aec760e5ded985626e3766b50d0e3e02def73d29() {
 }
 
 #[test]
-fn test_d79f0c071d66d4a46182372ff56e55951199f31006f623230237d567() {
+fn test_52bc5c52d1d29e812e20697130033c6e6bd1afc573a78ea85d61d790() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -3987,12 +3987,12 @@ fn test_d79f0c071d66d4a46182372ff56e55951199f31006f623230237d567() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_4bd15592fedf02f774998db6dfbc9e92bdb54d669d9722bf60f3ae05() {
+fn test_b390ceadac601ac21217a9e177a8c69067428d82d1f32c8ad7013fa8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4008,7 +4008,7 @@ fn test_4bd15592fedf02f774998db6dfbc9e92bdb54d669d9722bf60f3ae05() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4016,7 +4016,7 @@ fn test_4bd15592fedf02f774998db6dfbc9e92bdb54d669d9722bf60f3ae05() {
 }
 
 #[test]
-fn test_9dbb05856bcba0b5e92f5c1a2c29892a86e3b986aa15b8a0bb5e7ade() {
+fn test_829b2d40486beb222742cf61169e947ba33048a0d03beb0a08fced05() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4032,7 +4032,7 @@ fn test_9dbb05856bcba0b5e92f5c1a2c29892a86e3b986aa15b8a0bb5e7ade() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4040,7 +4040,7 @@ fn test_9dbb05856bcba0b5e92f5c1a2c29892a86e3b986aa15b8a0bb5e7ade() {
 }
 
 #[test]
-fn test_581cf81573afa927a815f8b92b6cc55d761635b928828594830f94db() {
+fn test_df4bd5abac9651056fae31ce8cd90c6b3e3bdf06f10e957aff4f5b43() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4056,7 +4056,7 @@ fn test_581cf81573afa927a815f8b92b6cc55d761635b928828594830f94db() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4064,7 +4064,7 @@ fn test_581cf81573afa927a815f8b92b6cc55d761635b928828594830f94db() {
 }
 
 #[test]
-fn test_5500337756cdfcb86b417f834d9c7e52267e5f810076199bf7541366() {
+fn test_df72ec8230b00071f43a797c51c6081c23cdc2ceed79baab5405016f() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4080,7 +4080,7 @@ fn test_5500337756cdfcb86b417f834d9c7e52267e5f810076199bf7541366() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4088,7 +4088,7 @@ fn test_5500337756cdfcb86b417f834d9c7e52267e5f810076199bf7541366() {
 }
 
 #[test]
-fn test_be3ab94b7c9794c8ce63979fc3dc0fc519704fc29522c104fa1061db() {
+fn test_225462ea5425878e213d72cb77ef39859acf053bd1b5803057f2bed8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4103,6 +4103,379 @@ fn test_be3ab94b7c9794c8ce63979fc3dc0fc519704fc29522c104fa1061db() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+}
+
+#[test]
+fn test_061da9c720104ca623958ae278fc286b8b29cfa7d44048fce15b7a30() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_d1214951e79590bf246f9ccd4efe5b35168f270d44f7424b6a6776e5() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_c5edf4253c0d257865d5b9f791117a697794950a5749b6abc1e2f65f() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_3626fd483a120b9212e2f477d573660874b8ee374640138613f53c6e() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_34786789639d2832beddaa52041f9f9beab2c1bab2e463cc1066b31a() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[49u8,][..]);
+}
+
+#[test]
+fn test_98adcbc49b54bf9b8c1c57342c6f2ed405f8bd049d6565d6c1909fc0() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_30209a5be2983ce24d3a865fc6a1e672079d3c10a08b771b91ef3b08() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_58138e08422217b5f1add492866f46a4b092bb9307a6741c0a27baa2() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_d5755cc95aa591c3c2b4364d8b57089a2deba1dc718b19db5f1866bc() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_5ddb9c34aef49344827ab1f543b72ff291b70c0852ae96c8f4d60025() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[49u8,][..]);
+}
+
+#[test]
+fn test_fa205b7f7bae5c6b292c7242e9974a48c179228356d551449cafdb3c() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_fa4d59fbef8c9fcb4f254e83c9407a1409512734808d2f460175485e() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_c8fef4f0ae8b45e944fa64d6c664b325c557f059737750f541733947() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_25ddd8699f5d7467ffde4c6e8b10c03963eaf6f902db9e4c3cd569c3() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_29fb98e8f4b9e8132988a71a4e26432ea130d3dc95e34b1fed5436c5() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[std::str::from_utf8(
+                &[
+                    97u8, 98u8, 99u8, 32u8, 32u8, 32u8, 32u8, 100u8, 101u8,
+                    102u8,
+                ][..],
+            )
+            .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 1usize, 0usize, 1usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 8usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }

--- a/rust_backend/jieba_vim_rs_core/tests/vim_v8_2_2876_py311.rs
+++ b/rust_backend/jieba_vim_rs_core/tests/vim_v8_2_2876_py311.rs
@@ -8,7 +8,7 @@ use jieba_vim_rs_core::token::Tokenizer;
 use keyword_cutter::KeywordCutter;
 
 #[test]
-fn test_698e57d0555d71c2d35a6b462c2af57b8ff017a14aff967cf1c3afbe() {
+fn test_c49507d01cdbea465d32314ceb801d9c8f254abc9c6f69815f182df8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -22,11 +22,11 @@ fn test_698e57d0555d71c2d35a6b462c2af57b8ff017a14aff967cf1c3afbe() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_706d85f12b47c3d525af804374cbc7e241aa86cc95e22e64264096ba() {
+fn test_8cce72cc00faa068725a1fe04b88053850a3f2000273e4f4730c6053() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -40,11 +40,11 @@ fn test_706d85f12b47c3d525af804374cbc7e241aa86cc95e22e64264096ba() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_80079981ca7ca6dd775d356f8d924c607deffc768fa0018f8b12be2a() {
+fn test_03a125e3f6590812f466d308ddc74afb24d01987a305b40f4eb8d9b1() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -58,11 +58,11 @@ fn test_80079981ca7ca6dd775d356f8d924c607deffc768fa0018f8b12be2a() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_8296af34e1f15c6444a53271d4d5f75a7eae56f85b851e01798dca1f() {
+fn test_10b646de08ba83ad3a6d33fabcde1c1c5fadc694e8d3a5b4088a3744() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -76,11 +76,11 @@ fn test_8296af34e1f15c6444a53271d4d5f75a7eae56f85b851e01798dca1f() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_797f49bf8ea25f1bafdb3b8d59477ea2447dfbbd137facedb78198ce() {
+fn test_3a6b4a36a2338d2844f0df72ced159c538450f9783bb8b3e0cf9e472() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -94,11 +94,11 @@ fn test_797f49bf8ea25f1bafdb3b8d59477ea2447dfbbd137facedb78198ce() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_7015f41f9bfabaa3bfc6ae2697658484cfee45d53c4341f34edc0f10() {
+fn test_329b00bed6a566f63230dff020b2d3c73b5123e211812ddd9f57429b() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -112,11 +112,11 @@ fn test_7015f41f9bfabaa3bfc6ae2697658484cfee45d53c4341f34edc0f10() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_c209f30411450c7334ad40b70090d535cb0fa726ee00a3773550a0c5() {
+fn test_f09570f84730fa18dae7fff574e9d718d9fde747f5cc3fe797069d47() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -130,11 +130,11 @@ fn test_c209f30411450c7334ad40b70090d535cb0fa726ee00a3773550a0c5() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_202e4390a90c3411730e2a0c0d8c6684d00266d1e0231de11107d539() {
+fn test_4ab46fe2887d1522e96230eccb0894f4adb901a241a5b428612d9b14() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -148,11 +148,11 @@ fn test_202e4390a90c3411730e2a0c0d8c6684d00266d1e0231de11107d539() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_52135bf88ac6b5780b7c45bce3e75aceaff381984bad60d4a07aa516() {
+fn test_cf51bdeb6cae4ca1d663f0040b03ef23d3364c5f1a5bdb63f7be2b23() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -166,11 +166,11 @@ fn test_52135bf88ac6b5780b7c45bce3e75aceaff381984bad60d4a07aa516() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_4c0437ad690881933de761f489767067a0c46e5ae6e6d26e49d4d92c() {
+fn test_2e06b3142444ec8d799820b31e62d6d33c60e501e69922c682043f13() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -184,11 +184,11 @@ fn test_4c0437ad690881933de761f489767067a0c46e5ae6e6d26e49d4d92c() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_4122b22abea40181a71e20fd6f0f4fe698b0eb1b43ed678e8cfe19bb() {
+fn test_a23235e47791c4c2df0c9b13493a3c9832e4caa21cede2dba0b86cd9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -202,11 +202,11 @@ fn test_4122b22abea40181a71e20fd6f0f4fe698b0eb1b43ed678e8cfe19bb() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_1e77aa1259b352d0424c4810c2c06e8210f88200edad7cd574f28425() {
+fn test_38600c9b3ad5e0e4ddb5625882bf02c84436780f9a6296e16b2a1de3() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -220,11 +220,11 @@ fn test_1e77aa1259b352d0424c4810c2c06e8210f88200edad7cd574f28425() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_46f6b57c58a49bc312b67f455da23cf0bcfb9a5b869466586a9a05d0() {
+fn test_be520fc284952bcd9583f04fa1c63ad706c032517f4df840518cdffc() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -238,11 +238,11 @@ fn test_46f6b57c58a49bc312b67f455da23cf0bcfb9a5b869466586a9a05d0() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_d7dd1d63585a4759bdcf74ac3497bf8383aac9be662bf228f908342e() {
+fn test_a96daab181124c5a19a423777f5aee4ce188f1c837f5b4ee5c9ca04a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -256,11 +256,11 @@ fn test_d7dd1d63585a4759bdcf74ac3497bf8383aac9be662bf228f908342e() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_b84918bb3e786c4d846a9e78e010500fea8f291803b6bda22850955b() {
+fn test_69aeb41ce405f3b2dcdc586ea6e1aaffcf3630053e14b5bc9fccc7de() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -274,11 +274,11 @@ fn test_b84918bb3e786c4d846a9e78e010500fea8f291803b6bda22850955b() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_6c6aa33a9bc7195ba3f736ebd073cc9fb0106e09465b343f773279b3() {
+fn test_1820a6b27c57b06f594755069925c9ac174c225dc6b6d9bc02161bb6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -292,7 +292,7 @@ fn test_6c6aa33a9bc7195ba3f736ebd073cc9fb0106e09465b343f773279b3() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
@@ -848,7 +848,7 @@ fn test_179910635d6c8841031d9b99aa239b76bf7dda8c81732a7f46b42e02() {
 }
 
 #[test]
-fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
+fn test_8fb704e4f7569d63dbd32678f9b83a8481299a11154abcbbcd207451() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -863,7 +863,7 @@ fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -871,7 +871,7 @@ fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
 }
 
 #[test]
-fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
+fn test_44a6e532bc15add989567d8b6eda27343830dcb2c32fd2bcc60bf065() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -886,7 +886,7 @@ fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -894,7 +894,7 @@ fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
 }
 
 #[test]
-fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
+fn test_c7d2120a5a8abb067dc68f04172115594efb14ab0f3dfb6862dfa154() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -910,7 +910,7 @@ fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 3usize, 0usize, 3usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 5usize, 0usize]);
@@ -918,7 +918,7 @@ fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
 }
 
 #[test]
-fn test_eff464fb67b28ce0d4d2e332574c68f8e34290264f8afdfa46c69058() {
+fn test_783df2d6a656f6a846c1023d9b79d7ee219cd804f69b199650dbbf04() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -933,7 +933,7 @@ fn test_eff464fb67b28ce0d4d2e332574c68f8e34290264f8afdfa46c69058() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -941,7 +941,7 @@ fn test_eff464fb67b28ce0d4d2e332574c68f8e34290264f8afdfa46c69058() {
 }
 
 #[test]
-fn test_d074a9ae8c2d202e384b62a0610dbc75161d574710ecfc68d264303c() {
+fn test_0dbae4fbbfcfad38d75785c1a7d576ea33ed736abc7817e6c0e309bd() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -959,7 +959,7 @@ fn test_d074a9ae8c2d202e384b62a0610dbc75161d574710ecfc68d264303c() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -967,7 +967,7 @@ fn test_d074a9ae8c2d202e384b62a0610dbc75161d574710ecfc68d264303c() {
 }
 
 #[test]
-fn test_c420a9092c7354bf89945603bbb9bbcb7b23c85c400e955716253a00() {
+fn test_322fd55e5e45035b183d456b8bb0d7e84175b5d4e40f0cc4c0a48231() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -985,7 +985,7 @@ fn test_c420a9092c7354bf89945603bbb9bbcb7b23c85c400e955716253a00() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -993,7 +993,7 @@ fn test_c420a9092c7354bf89945603bbb9bbcb7b23c85c400e955716253a00() {
 }
 
 #[test]
-fn test_0d8915939e7a875257c545577c6f6be5fd3e47948820bc13e67cdaf8() {
+fn test_8a035514a1e16aef0109e47adaf150e82ee3e2967605eb7f3fa4bc73() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1011,7 +1011,7 @@ fn test_0d8915939e7a875257c545577c6f6be5fd3e47948820bc13e67cdaf8() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize, 2usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -1019,7 +1019,7 @@ fn test_0d8915939e7a875257c545577c6f6be5fd3e47948820bc13e67cdaf8() {
 }
 
 #[test]
-fn test_2e48878e789e89cbdec64e3a7bd94a361733ea7ee438c64178aa83be() {
+fn test_1f175043c100f5a93d3b94ea6e2ceb8ad9595171930226d632e3d73c() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1037,7 +1037,7 @@ fn test_2e48878e789e89cbdec64e3a7bd94a361733ea7ee438c64178aa83be() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -1045,7 +1045,7 @@ fn test_2e48878e789e89cbdec64e3a7bd94a361733ea7ee438c64178aa83be() {
 }
 
 #[test]
-fn test_f1c8ff7972854262d9ae5b10d6017fbfa44ac7b8e248669d516394a7() {
+fn test_743b3c4ea7873f4f78aa00e6be0fc8b982a7dabd9ef75d9ea84ae1a0() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1064,7 +1064,7 @@ fn test_f1c8ff7972854262d9ae5b10d6017fbfa44ac7b8e248669d516394a7() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize, 2usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -1072,7 +1072,7 @@ fn test_f1c8ff7972854262d9ae5b10d6017fbfa44ac7b8e248669d516394a7() {
 }
 
 #[test]
-fn test_1605a5ffa5d509d54f2834587a5dc5116e43aa4526f35f65e54a398c() {
+fn test_451e7c72edc394f97556568d81ec6ee9e9d25e8f045fb7b8f791113f() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1091,7 +1091,7 @@ fn test_1605a5ffa5d509d54f2834587a5dc5116e43aa4526f35f65e54a398c() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize, 2usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -1099,7 +1099,7 @@ fn test_1605a5ffa5d509d54f2834587a5dc5116e43aa4526f35f65e54a398c() {
 }
 
 #[test]
-fn test_6e70ecf32b14e1c4a111aab8c79d80096e276bc2cb85c670d07ae4ff() {
+fn test_95f6c2b8150ec1b2f909fc8bd50ca6f57ca5e5bc237188b42ffa8c06() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1119,7 +1119,7 @@ fn test_6e70ecf32b14e1c4a111aab8c79d80096e276bc2cb85c670d07ae4ff() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize, 6usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -1127,7 +1127,7 @@ fn test_6e70ecf32b14e1c4a111aab8c79d80096e276bc2cb85c670d07ae4ff() {
 }
 
 #[test]
-fn test_2aaef08602951d1946d055d4174ab56a682bbb3fbefa9100a485f0f6() {
+fn test_dacd2e355de2ad2cd8c7f8917f82c6a432d9ce87f649a25447615190() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1149,7 +1149,7 @@ fn test_2aaef08602951d1946d055d4174ab56a682bbb3fbefa9100a485f0f6() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize, 4usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -1157,7 +1157,7 @@ fn test_2aaef08602951d1946d055d4174ab56a682bbb3fbefa9100a485f0f6() {
 }
 
 #[test]
-fn test_09a4e1ae715d8a8b657741c2ce71a8620a0a31d62687be7a7411edd6() {
+fn test_5140fce8366bba565d9e5bd258deae8b35b185073e6ede9308c337c0() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1179,7 +1179,7 @@ fn test_09a4e1ae715d8a8b657741c2ce71a8620a0a31d62687be7a7411edd6() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1187,7 +1187,7 @@ fn test_09a4e1ae715d8a8b657741c2ce71a8620a0a31d62687be7a7411edd6() {
 }
 
 #[test]
-fn test_64eaeef8e77814bff15fcb065fcd23ca80eb8b51c1f14efc92e32740() {
+fn test_3f83629c73bb43a38896d71d28d8c1f703c9eccc95fa0520c5887f8b() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1208,7 +1208,7 @@ fn test_64eaeef8e77814bff15fcb065fcd23ca80eb8b51c1f14efc92e32740() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1216,7 +1216,7 @@ fn test_64eaeef8e77814bff15fcb065fcd23ca80eb8b51c1f14efc92e32740() {
 }
 
 #[test]
-fn test_e045074ead88095b110cca6565bde1dc2d981ca9535c2311c425cb80() {
+fn test_40bc60e2568bebf2ed73174d648d8464a10cba79957124462f01245a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1239,7 +1239,7 @@ fn test_e045074ead88095b110cca6565bde1dc2d981ca9535c2311c425cb80() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize, 6usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1247,7 +1247,7 @@ fn test_e045074ead88095b110cca6565bde1dc2d981ca9535c2311c425cb80() {
 }
 
 #[test]
-fn test_c5b6479f8b77261426ea8846e93f6c532950988647215c0d59571006() {
+fn test_2304ebf0caf809b4b1e1ee11db994de530df34d2db7e755b80bd024e() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1273,7 +1273,7 @@ fn test_c5b6479f8b77261426ea8846e93f6c532950988647215c0d59571006() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 7usize, 0usize, 7usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 7usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1281,7 +1281,7 @@ fn test_c5b6479f8b77261426ea8846e93f6c532950988647215c0d59571006() {
 }
 
 #[test]
-fn test_ff8e551260f6a64d3825a6055cfc3de7e64a5d87ebefd6ea9f8c044e() {
+fn test_213a87b8ef26620353982ee99e728eba8136741c3163d9258027c389() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1308,7 +1308,7 @@ fn test_ff8e551260f6a64d3825a6055cfc3de7e64a5d87ebefd6ea9f8c044e() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize, 2usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1316,7 +1316,7 @@ fn test_ff8e551260f6a64d3825a6055cfc3de7e64a5d87ebefd6ea9f8c044e() {
 }
 
 #[test]
-fn test_9376aa7484a2d0775d9ce7286ef702070ad2348562ac6277e44d2dcd() {
+fn test_b993f000f06f1d195e616223a96725c1a405b9dd5c2c04d971aad08d() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1343,7 +1343,7 @@ fn test_9376aa7484a2d0775d9ce7286ef702070ad2348562ac6277e44d2dcd() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 5usize, 7usize, 0usize]);
@@ -4162,7 +4162,7 @@ fn test_750edd71d543211b4135450d760ce7d21c0d170c1f7d7020707100da() {
 }
 
 #[test]
-fn test_a992ffad30994ab1b69d9c8e9a9a1a5f534611609625ec35c23f30e1() {
+fn test_807d45a97423b9a26ad8e521ae3af6af6e486e6182f2bff0ed940896() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4176,12 +4176,12 @@ fn test_a992ffad30994ab1b69d9c8e9a9a1a5f534611609625ec35c23f30e1() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_eefce73591308c046661dfbaf4c805dd3c5404adb1fafa572970d2e8() {
+fn test_ab0aae06b3494ea64cbeaf534532adc26076748b2b5f51b6907d6fed() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4196,7 +4196,7 @@ fn test_eefce73591308c046661dfbaf4c805dd3c5404adb1fafa572970d2e8() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4204,7 +4204,7 @@ fn test_eefce73591308c046661dfbaf4c805dd3c5404adb1fafa572970d2e8() {
 }
 
 #[test]
-fn test_b38a46fe201eb488600338b76007705fe4a16ab4b09164d302d50e00() {
+fn test_7a08e780d59ca162920720140d6eac0298d5602103bb4f4267bd7bba() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4219,7 +4219,7 @@ fn test_b38a46fe201eb488600338b76007705fe4a16ab4b09164d302d50e00() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4227,7 +4227,7 @@ fn test_b38a46fe201eb488600338b76007705fe4a16ab4b09164d302d50e00() {
 }
 
 #[test]
-fn test_a1ef97f8339c88caf98baef20780168689c855c926fa04377201efd0() {
+fn test_ac7de5b56c38b27cada9e53a08c555f099cf086f70553eb82317c02a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4242,7 +4242,7 @@ fn test_a1ef97f8339c88caf98baef20780168689c855c926fa04377201efd0() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4250,7 +4250,7 @@ fn test_a1ef97f8339c88caf98baef20780168689c855c926fa04377201efd0() {
 }
 
 #[test]
-fn test_4f1a357464eca09a6939bb40085ec6cb52ec80f439fc6262e540d913() {
+fn test_f05af16087f08376d4ff0b9037efa5d87617c337d034f509aee05020() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4265,7 +4265,7 @@ fn test_4f1a357464eca09a6939bb40085ec6cb52ec80f439fc6262e540d913() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4273,7 +4273,7 @@ fn test_4f1a357464eca09a6939bb40085ec6cb52ec80f439fc6262e540d913() {
 }
 
 #[test]
-fn test_eccea143a32d69b022bd86407f61f2da3591283e849dbd0e250653f3() {
+fn test_70c7c0c7062fea40144b1df3c438c1a6800a36360c847fad5f325090() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4287,12 +4287,12 @@ fn test_eccea143a32d69b022bd86407f61f2da3591283e849dbd0e250653f3() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_48ccbb2888a0739e3724192c28268f97491d807c5943b595384c3efa() {
+fn test_b90575a32700f6f9ad2d28e5b75dc02168316454d79d2bdfd5adbebf() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4307,7 +4307,7 @@ fn test_48ccbb2888a0739e3724192c28268f97491d807c5943b595384c3efa() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4315,7 +4315,7 @@ fn test_48ccbb2888a0739e3724192c28268f97491d807c5943b595384c3efa() {
 }
 
 #[test]
-fn test_152111b7c04892e7d7af6e3899fe3c2ce4a9be5e4d7eb098754304c4() {
+fn test_b2e09f2a3ed0972ecf0bdb1394b590891b3c28404c1191e63a5307a9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4330,7 +4330,7 @@ fn test_152111b7c04892e7d7af6e3899fe3c2ce4a9be5e4d7eb098754304c4() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4338,7 +4338,7 @@ fn test_152111b7c04892e7d7af6e3899fe3c2ce4a9be5e4d7eb098754304c4() {
 }
 
 #[test]
-fn test_05ceda276d1ec4e67e1a1eea60a7ffd677f388bb35afffcbf9457bfc() {
+fn test_b98ec6df773bb21e0c060913b69cf62345dec1a60e1fc2f8ee85bee9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4353,7 +4353,7 @@ fn test_05ceda276d1ec4e67e1a1eea60a7ffd677f388bb35afffcbf9457bfc() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4361,7 +4361,7 @@ fn test_05ceda276d1ec4e67e1a1eea60a7ffd677f388bb35afffcbf9457bfc() {
 }
 
 #[test]
-fn test_d6eeeafaaf22846ebbb4ab3a52e16f9ec45d97dcb79c465be557af9c() {
+fn test_3dca3e56f11d91615351d2140f58ffa9a78b710cb5b333debf88a2e6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4376,7 +4376,7 @@ fn test_d6eeeafaaf22846ebbb4ab3a52e16f9ec45d97dcb79c465be557af9c() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4384,7 +4384,7 @@ fn test_d6eeeafaaf22846ebbb4ab3a52e16f9ec45d97dcb79c465be557af9c() {
 }
 
 #[test]
-fn test_4aedc8297096d3cbf3ba1f92b60ece1817adbcff86b02a2f615b47f0() {
+fn test_6397f3c05f1f81dd29cdc60722e40a1757e3b597c70ceb7892d38ff9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4399,12 +4399,12 @@ fn test_4aedc8297096d3cbf3ba1f92b60ece1817adbcff86b02a2f615b47f0() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_88c65e0880222a77a6081b56b91a328bce58c56a078f7390e812deb6() {
+fn test_bdc1818c4128642310cc444d854119e248c7dbdfc441b739841bafe8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4420,7 +4420,7 @@ fn test_88c65e0880222a77a6081b56b91a328bce58c56a078f7390e812deb6() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4428,7 +4428,7 @@ fn test_88c65e0880222a77a6081b56b91a328bce58c56a078f7390e812deb6() {
 }
 
 #[test]
-fn test_7f7930febf1a953e9a16209214df24b1e25668fef6646e4ba73a0362() {
+fn test_1661b19ff8e3e557961d0726a5fc52562be88f81857936b658d8990a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4444,7 +4444,7 @@ fn test_7f7930febf1a953e9a16209214df24b1e25668fef6646e4ba73a0362() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4452,7 +4452,7 @@ fn test_7f7930febf1a953e9a16209214df24b1e25668fef6646e4ba73a0362() {
 }
 
 #[test]
-fn test_6a812937b162594ae6d2e7186838bee58007fe0565ea13d1ad120fad() {
+fn test_8fb5b0a784b85027efe2db42a4aabb3f005de958f5ce277d50695394() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4468,7 +4468,7 @@ fn test_6a812937b162594ae6d2e7186838bee58007fe0565ea13d1ad120fad() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4476,7 +4476,7 @@ fn test_6a812937b162594ae6d2e7186838bee58007fe0565ea13d1ad120fad() {
 }
 
 #[test]
-fn test_c63bffe550c4ccc0a2e22ba7376915c8fdb3b5ea4cefc35d5fe645e1() {
+fn test_f45b50ec09fdd24cca12480139a4deebe37dc4c4c2170394dc573e91() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4492,7 +4492,7 @@ fn test_c63bffe550c4ccc0a2e22ba7376915c8fdb3b5ea4cefc35d5fe645e1() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4500,7 +4500,7 @@ fn test_c63bffe550c4ccc0a2e22ba7376915c8fdb3b5ea4cefc35d5fe645e1() {
 }
 
 #[test]
-fn test_d98154113ad984467223c941198bb907e66d4317ca462332dcc65a3a() {
+fn test_716b2fa13881778351537e9c4123e6567e3d11eb591c63dd7d691aee() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4515,12 +4515,12 @@ fn test_d98154113ad984467223c941198bb907e66d4317ca462332dcc65a3a() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_554c80ccc267415f7cf500e65eb4a6113ee70029b044b06e433cd1c1() {
+fn test_dc9412453869cba39223365b3832978f07d179ff42f5c6ade9bf182e() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4536,7 +4536,7 @@ fn test_554c80ccc267415f7cf500e65eb4a6113ee70029b044b06e433cd1c1() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4544,7 +4544,7 @@ fn test_554c80ccc267415f7cf500e65eb4a6113ee70029b044b06e433cd1c1() {
 }
 
 #[test]
-fn test_2c048eebcf3d97292e8f48939bb99df29588d8ef7cb76ecf0ae8612c() {
+fn test_e5c8e45e5a425993546ba298f22a19f97d59038bdce0ed68a4f5ec57() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4560,7 +4560,7 @@ fn test_2c048eebcf3d97292e8f48939bb99df29588d8ef7cb76ecf0ae8612c() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4568,7 +4568,7 @@ fn test_2c048eebcf3d97292e8f48939bb99df29588d8ef7cb76ecf0ae8612c() {
 }
 
 #[test]
-fn test_ba48c5ef5f088e1ffe2f87f9b9bff014d1b6b734bc2180ee57aa41c0() {
+fn test_91bd486eac76569cc5e2d065f678f3be54c0c6323e4f4f2923ec9d01() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4584,7 +4584,7 @@ fn test_ba48c5ef5f088e1ffe2f87f9b9bff014d1b6b734bc2180ee57aa41c0() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4592,7 +4592,7 @@ fn test_ba48c5ef5f088e1ffe2f87f9b9bff014d1b6b734bc2180ee57aa41c0() {
 }
 
 #[test]
-fn test_44d54d8133ebf73a83c7e6a0b7624efdfb731995e4bcf9b6d06accee() {
+fn test_9c86e3f4ef97dd61358cf6a58949ac0ddbdc415af9e909161642ccdf() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4608,7 +4608,7 @@ fn test_44d54d8133ebf73a83c7e6a0b7624efdfb731995e4bcf9b6d06accee() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4616,7 +4616,7 @@ fn test_44d54d8133ebf73a83c7e6a0b7624efdfb731995e4bcf9b6d06accee() {
 }
 
 #[test]
-fn test_d3d81f9ecdc9ef5e728f727285133b79076050e8c6a85801a4791d1b() {
+fn test_866d6c41c9f83bd0365934c1411f4263c2de1077c1305e4db4083770() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4631,6 +4631,379 @@ fn test_d3d81f9ecdc9ef5e728f727285133b79076050e8c6a85801a4791d1b() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+}
+
+#[test]
+fn test_d23ef0dcfefcffd8c169aa1538b1b4fc5e628d714e845c10534de0ed() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_15c1c12bf544e60c7b5ce6b60cfd9ada5b5324807f57fca40864731d() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_8665baa1f140f32841a8ba0df76134ec7b9819cae86153a22161ae2d() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_0dfac80ebf82a76046f65e74d2d2a409a7b8f4cfe1099af744e4e3d4() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_68c9e1c93efe92315a3080c80f622918034d9d890021dfefbd83059b() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[49u8,][..]);
+}
+
+#[test]
+fn test_86a5f2426bd6ec1aaff620ac4d1581d5d63ded4a9b5276a4f087e6af() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_cce5173b5929e88dc5779a1afdd9c33f8fa9f12b6c1c392bb4edebec() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_acd386c78e0d1fe690dfb8e60797a8410b091d64898bcdf27ed01e9c() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_7574e301eb53b8bd441f894bf9601019aeb5cebf27a9612dd6d87ded() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_e4701c405157aa2ddb5144b4a67620453adbdd69677e1079c24650a2() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[49u8,][..]);
+}
+
+#[test]
+fn test_638c753326c00b29253ef5263bd51ca4a91ee08578e7f2490f713892() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_2c971e5aefcf371827f27eedd9094870d228ec7584ec422297bc31ea() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_827b5d25cf4c97ca3aba5749af662e802fe85164ee062fdeee3aa982() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_1f4244ef1dc76da467c59a7b26de580d8e9f6b65fecf48e8a4ed6b69() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_d4dbfdba4fa441106899d80aa34bfb0f4cfc495c33dd885d0d2d1db7() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[std::str::from_utf8(
+                &[
+                    97u8, 98u8, 99u8, 32u8, 32u8, 32u8, 32u8, 100u8, 101u8,
+                    102u8,
+                ][..],
+            )
+            .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 1usize, 0usize, 1usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 8usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }

--- a/rust_backend/jieba_vim_rs_core/tests/vim_v9_1_0000_py311.rs
+++ b/rust_backend/jieba_vim_rs_core/tests/vim_v9_1_0000_py311.rs
@@ -8,7 +8,7 @@ use jieba_vim_rs_core::token::Tokenizer;
 use keyword_cutter::KeywordCutter;
 
 #[test]
-fn test_698e57d0555d71c2d35a6b462c2af57b8ff017a14aff967cf1c3afbe() {
+fn test_c49507d01cdbea465d32314ceb801d9c8f254abc9c6f69815f182df8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -22,11 +22,11 @@ fn test_698e57d0555d71c2d35a6b462c2af57b8ff017a14aff967cf1c3afbe() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_706d85f12b47c3d525af804374cbc7e241aa86cc95e22e64264096ba() {
+fn test_8cce72cc00faa068725a1fe04b88053850a3f2000273e4f4730c6053() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -40,11 +40,11 @@ fn test_706d85f12b47c3d525af804374cbc7e241aa86cc95e22e64264096ba() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_80079981ca7ca6dd775d356f8d924c607deffc768fa0018f8b12be2a() {
+fn test_03a125e3f6590812f466d308ddc74afb24d01987a305b40f4eb8d9b1() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -58,11 +58,11 @@ fn test_80079981ca7ca6dd775d356f8d924c607deffc768fa0018f8b12be2a() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_8296af34e1f15c6444a53271d4d5f75a7eae56f85b851e01798dca1f() {
+fn test_10b646de08ba83ad3a6d33fabcde1c1c5fadc694e8d3a5b4088a3744() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -76,11 +76,11 @@ fn test_8296af34e1f15c6444a53271d4d5f75a7eae56f85b851e01798dca1f() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_797f49bf8ea25f1bafdb3b8d59477ea2447dfbbd137facedb78198ce() {
+fn test_3a6b4a36a2338d2844f0df72ced159c538450f9783bb8b3e0cf9e472() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -94,11 +94,11 @@ fn test_797f49bf8ea25f1bafdb3b8d59477ea2447dfbbd137facedb78198ce() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_7015f41f9bfabaa3bfc6ae2697658484cfee45d53c4341f34edc0f10() {
+fn test_329b00bed6a566f63230dff020b2d3c73b5123e211812ddd9f57429b() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -112,11 +112,11 @@ fn test_7015f41f9bfabaa3bfc6ae2697658484cfee45d53c4341f34edc0f10() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_c209f30411450c7334ad40b70090d535cb0fa726ee00a3773550a0c5() {
+fn test_f09570f84730fa18dae7fff574e9d718d9fde747f5cc3fe797069d47() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -130,11 +130,11 @@ fn test_c209f30411450c7334ad40b70090d535cb0fa726ee00a3773550a0c5() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_202e4390a90c3411730e2a0c0d8c6684d00266d1e0231de11107d539() {
+fn test_4ab46fe2887d1522e96230eccb0894f4adb901a241a5b428612d9b14() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -148,11 +148,11 @@ fn test_202e4390a90c3411730e2a0c0d8c6684d00266d1e0231de11107d539() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_52135bf88ac6b5780b7c45bce3e75aceaff381984bad60d4a07aa516() {
+fn test_cf51bdeb6cae4ca1d663f0040b03ef23d3364c5f1a5bdb63f7be2b23() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -166,11 +166,11 @@ fn test_52135bf88ac6b5780b7c45bce3e75aceaff381984bad60d4a07aa516() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_4c0437ad690881933de761f489767067a0c46e5ae6e6d26e49d4d92c() {
+fn test_2e06b3142444ec8d799820b31e62d6d33c60e501e69922c682043f13() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -184,11 +184,11 @@ fn test_4c0437ad690881933de761f489767067a0c46e5ae6e6d26e49d4d92c() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_4122b22abea40181a71e20fd6f0f4fe698b0eb1b43ed678e8cfe19bb() {
+fn test_a23235e47791c4c2df0c9b13493a3c9832e4caa21cede2dba0b86cd9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -202,11 +202,11 @@ fn test_4122b22abea40181a71e20fd6f0f4fe698b0eb1b43ed678e8cfe19bb() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_1e77aa1259b352d0424c4810c2c06e8210f88200edad7cd574f28425() {
+fn test_38600c9b3ad5e0e4ddb5625882bf02c84436780f9a6296e16b2a1de3() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -220,11 +220,11 @@ fn test_1e77aa1259b352d0424c4810c2c06e8210f88200edad7cd574f28425() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_46f6b57c58a49bc312b67f455da23cf0bcfb9a5b869466586a9a05d0() {
+fn test_be520fc284952bcd9583f04fa1c63ad706c032517f4df840518cdffc() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -238,11 +238,11 @@ fn test_46f6b57c58a49bc312b67f455da23cf0bcfb9a5b869466586a9a05d0() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_d7dd1d63585a4759bdcf74ac3497bf8383aac9be662bf228f908342e() {
+fn test_a96daab181124c5a19a423777f5aee4ce188f1c837f5b4ee5c9ca04a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -256,11 +256,11 @@ fn test_d7dd1d63585a4759bdcf74ac3497bf8383aac9be662bf228f908342e() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_b84918bb3e786c4d846a9e78e010500fea8f291803b6bda22850955b() {
+fn test_69aeb41ce405f3b2dcdc586ea6e1aaffcf3630053e14b5bc9fccc7de() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -274,11 +274,11 @@ fn test_b84918bb3e786c4d846a9e78e010500fea8f291803b6bda22850955b() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
-fn test_6c6aa33a9bc7195ba3f736ebd073cc9fb0106e09465b343f773279b3() {
+fn test_1820a6b27c57b06f594755069925c9ac174c225dc6b6d9bc02161bb6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -292,7 +292,7 @@ fn test_6c6aa33a9bc7195ba3f736ebd073cc9fb0106e09465b343f773279b3() {
             1000u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
 }
 
 #[test]
@@ -848,7 +848,7 @@ fn test_179910635d6c8841031d9b99aa239b76bf7dda8c81732a7f46b42e02() {
 }
 
 #[test]
-fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
+fn test_8fb704e4f7569d63dbd32678f9b83a8481299a11154abcbbcd207451() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -863,7 +863,7 @@ fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -871,7 +871,7 @@ fn test_81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0() {
 }
 
 #[test]
-fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
+fn test_44a6e532bc15add989567d8b6eda27343830dcb2c32fd2bcc60bf065() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -886,7 +886,7 @@ fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -894,7 +894,7 @@ fn test_d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824() {
 }
 
 #[test]
-fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
+fn test_c7d2120a5a8abb067dc68f04172115594efb14ab0f3dfb6862dfa154() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -910,7 +910,7 @@ fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 3usize, 0usize, 3usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 5usize, 0usize]);
@@ -918,7 +918,7 @@ fn test_c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686() {
 }
 
 #[test]
-fn test_eff464fb67b28ce0d4d2e332574c68f8e34290264f8afdfa46c69058() {
+fn test_783df2d6a656f6a846c1023d9b79d7ee219cd804f69b199650dbbf04() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -933,7 +933,7 @@ fn test_eff464fb67b28ce0d4d2e332574c68f8e34290264f8afdfa46c69058() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -941,7 +941,7 @@ fn test_eff464fb67b28ce0d4d2e332574c68f8e34290264f8afdfa46c69058() {
 }
 
 #[test]
-fn test_d074a9ae8c2d202e384b62a0610dbc75161d574710ecfc68d264303c() {
+fn test_0dbae4fbbfcfad38d75785c1a7d576ea33ed736abc7817e6c0e309bd() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -959,7 +959,7 @@ fn test_d074a9ae8c2d202e384b62a0610dbc75161d574710ecfc68d264303c() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -967,7 +967,7 @@ fn test_d074a9ae8c2d202e384b62a0610dbc75161d574710ecfc68d264303c() {
 }
 
 #[test]
-fn test_c420a9092c7354bf89945603bbb9bbcb7b23c85c400e955716253a00() {
+fn test_322fd55e5e45035b183d456b8bb0d7e84175b5d4e40f0cc4c0a48231() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -985,7 +985,7 @@ fn test_c420a9092c7354bf89945603bbb9bbcb7b23c85c400e955716253a00() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -993,7 +993,7 @@ fn test_c420a9092c7354bf89945603bbb9bbcb7b23c85c400e955716253a00() {
 }
 
 #[test]
-fn test_0d8915939e7a875257c545577c6f6be5fd3e47948820bc13e67cdaf8() {
+fn test_8a035514a1e16aef0109e47adaf150e82ee3e2967605eb7f3fa4bc73() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1011,7 +1011,7 @@ fn test_0d8915939e7a875257c545577c6f6be5fd3e47948820bc13e67cdaf8() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize, 2usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -1019,7 +1019,7 @@ fn test_0d8915939e7a875257c545577c6f6be5fd3e47948820bc13e67cdaf8() {
 }
 
 #[test]
-fn test_2e48878e789e89cbdec64e3a7bd94a361733ea7ee438c64178aa83be() {
+fn test_1f175043c100f5a93d3b94ea6e2ceb8ad9595171930226d632e3d73c() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1037,7 +1037,7 @@ fn test_2e48878e789e89cbdec64e3a7bd94a361733ea7ee438c64178aa83be() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -1045,7 +1045,7 @@ fn test_2e48878e789e89cbdec64e3a7bd94a361733ea7ee438c64178aa83be() {
 }
 
 #[test]
-fn test_f1c8ff7972854262d9ae5b10d6017fbfa44ac7b8e248669d516394a7() {
+fn test_743b3c4ea7873f4f78aa00e6be0fc8b982a7dabd9ef75d9ea84ae1a0() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1064,7 +1064,7 @@ fn test_f1c8ff7972854262d9ae5b10d6017fbfa44ac7b8e248669d516394a7() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize, 2usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -1072,7 +1072,7 @@ fn test_f1c8ff7972854262d9ae5b10d6017fbfa44ac7b8e248669d516394a7() {
 }
 
 #[test]
-fn test_1605a5ffa5d509d54f2834587a5dc5116e43aa4526f35f65e54a398c() {
+fn test_451e7c72edc394f97556568d81ec6ee9e9d25e8f045fb7b8f791113f() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1091,7 +1091,7 @@ fn test_1605a5ffa5d509d54f2834587a5dc5116e43aa4526f35f65e54a398c() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize, 2usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 3usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -1099,7 +1099,7 @@ fn test_1605a5ffa5d509d54f2834587a5dc5116e43aa4526f35f65e54a398c() {
 }
 
 #[test]
-fn test_6e70ecf32b14e1c4a111aab8c79d80096e276bc2cb85c670d07ae4ff() {
+fn test_95f6c2b8150ec1b2f909fc8bd50ca6f57ca5e5bc237188b42ffa8c06() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1119,7 +1119,7 @@ fn test_6e70ecf32b14e1c4a111aab8c79d80096e276bc2cb85c670d07ae4ff() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize, 6usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -1127,7 +1127,7 @@ fn test_6e70ecf32b14e1c4a111aab8c79d80096e276bc2cb85c670d07ae4ff() {
 }
 
 #[test]
-fn test_2aaef08602951d1946d055d4174ab56a682bbb3fbefa9100a485f0f6() {
+fn test_dacd2e355de2ad2cd8c7f8917f82c6a432d9ce87f649a25447615190() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1149,7 +1149,7 @@ fn test_2aaef08602951d1946d055d4174ab56a682bbb3fbefa9100a485f0f6() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize, 4usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -1157,7 +1157,7 @@ fn test_2aaef08602951d1946d055d4174ab56a682bbb3fbefa9100a485f0f6() {
 }
 
 #[test]
-fn test_09a4e1ae715d8a8b657741c2ce71a8620a0a31d62687be7a7411edd6() {
+fn test_5140fce8366bba565d9e5bd258deae8b35b185073e6ede9308c337c0() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1179,7 +1179,7 @@ fn test_09a4e1ae715d8a8b657741c2ce71a8620a0a31d62687be7a7411edd6() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1187,7 +1187,7 @@ fn test_09a4e1ae715d8a8b657741c2ce71a8620a0a31d62687be7a7411edd6() {
 }
 
 #[test]
-fn test_64eaeef8e77814bff15fcb065fcd23ca80eb8b51c1f14efc92e32740() {
+fn test_3f83629c73bb43a38896d71d28d8c1f703c9eccc95fa0520c5887f8b() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1208,7 +1208,7 @@ fn test_64eaeef8e77814bff15fcb065fcd23ca80eb8b51c1f14efc92e32740() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1216,7 +1216,7 @@ fn test_64eaeef8e77814bff15fcb065fcd23ca80eb8b51c1f14efc92e32740() {
 }
 
 #[test]
-fn test_e045074ead88095b110cca6565bde1dc2d981ca9535c2311c425cb80() {
+fn test_40bc60e2568bebf2ed73174d648d8464a10cba79957124462f01245a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1239,7 +1239,7 @@ fn test_e045074ead88095b110cca6565bde1dc2d981ca9535c2311c425cb80() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize, 6usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1247,7 +1247,7 @@ fn test_e045074ead88095b110cca6565bde1dc2d981ca9535c2311c425cb80() {
 }
 
 #[test]
-fn test_c5b6479f8b77261426ea8846e93f6c532950988647215c0d59571006() {
+fn test_2304ebf0caf809b4b1e1ee11db994de530df34d2db7e755b80bd024e() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1273,7 +1273,7 @@ fn test_c5b6479f8b77261426ea8846e93f6c532950988647215c0d59571006() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 7usize, 0usize, 7usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 7usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1281,7 +1281,7 @@ fn test_c5b6479f8b77261426ea8846e93f6c532950988647215c0d59571006() {
 }
 
 #[test]
-fn test_ff8e551260f6a64d3825a6055cfc3de7e64a5d87ebefd6ea9f8c044e() {
+fn test_213a87b8ef26620353982ee99e728eba8136741c3163d9258027c389() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1308,7 +1308,7 @@ fn test_ff8e551260f6a64d3825a6055cfc3de7e64a5d87ebefd6ea9f8c044e() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize, 2usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 2usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 2usize, 8usize, 0usize]);
@@ -1316,7 +1316,7 @@ fn test_ff8e551260f6a64d3825a6055cfc3de7e64a5d87ebefd6ea9f8c044e() {
 }
 
 #[test]
-fn test_9376aa7484a2d0775d9ce7286ef702070ad2348562ac6277e44d2dcd() {
+fn test_b993f000f06f1d195e616223a96725c1a405b9dd5c2c04d971aad08d() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -1343,7 +1343,7 @@ fn test_9376aa7484a2d0775d9ce7286ef702070ad2348562ac6277e44d2dcd() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 5usize, 7usize, 0usize]);
@@ -4162,7 +4162,7 @@ fn test_750edd71d543211b4135450d760ce7d21c0d170c1f7d7020707100da() {
 }
 
 #[test]
-fn test_a992ffad30994ab1b69d9c8e9a9a1a5f534611609625ec35c23f30e1() {
+fn test_807d45a97423b9a26ad8e521ae3af6af6e486e6182f2bff0ed940896() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4176,12 +4176,12 @@ fn test_a992ffad30994ab1b69d9c8e9a9a1a5f534611609625ec35c23f30e1() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_eefce73591308c046661dfbaf4c805dd3c5404adb1fafa572970d2e8() {
+fn test_ab0aae06b3494ea64cbeaf534532adc26076748b2b5f51b6907d6fed() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4196,7 +4196,7 @@ fn test_eefce73591308c046661dfbaf4c805dd3c5404adb1fafa572970d2e8() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4204,7 +4204,7 @@ fn test_eefce73591308c046661dfbaf4c805dd3c5404adb1fafa572970d2e8() {
 }
 
 #[test]
-fn test_b38a46fe201eb488600338b76007705fe4a16ab4b09164d302d50e00() {
+fn test_7a08e780d59ca162920720140d6eac0298d5602103bb4f4267bd7bba() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4219,7 +4219,7 @@ fn test_b38a46fe201eb488600338b76007705fe4a16ab4b09164d302d50e00() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4227,7 +4227,7 @@ fn test_b38a46fe201eb488600338b76007705fe4a16ab4b09164d302d50e00() {
 }
 
 #[test]
-fn test_a1ef97f8339c88caf98baef20780168689c855c926fa04377201efd0() {
+fn test_ac7de5b56c38b27cada9e53a08c555f099cf086f70553eb82317c02a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4242,7 +4242,7 @@ fn test_a1ef97f8339c88caf98baef20780168689c855c926fa04377201efd0() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4250,7 +4250,7 @@ fn test_a1ef97f8339c88caf98baef20780168689c855c926fa04377201efd0() {
 }
 
 #[test]
-fn test_4f1a357464eca09a6939bb40085ec6cb52ec80f439fc6262e540d913() {
+fn test_f05af16087f08376d4ff0b9037efa5d87617c337d034f509aee05020() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4265,7 +4265,7 @@ fn test_4f1a357464eca09a6939bb40085ec6cb52ec80f439fc6262e540d913() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4273,7 +4273,7 @@ fn test_4f1a357464eca09a6939bb40085ec6cb52ec80f439fc6262e540d913() {
 }
 
 #[test]
-fn test_eccea143a32d69b022bd86407f61f2da3591283e849dbd0e250653f3() {
+fn test_70c7c0c7062fea40144b1df3c438c1a6800a36360c847fad5f325090() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4287,12 +4287,12 @@ fn test_eccea143a32d69b022bd86407f61f2da3591283e849dbd0e250653f3() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_48ccbb2888a0739e3724192c28268f97491d807c5943b595384c3efa() {
+fn test_b90575a32700f6f9ad2d28e5b75dc02168316454d79d2bdfd5adbebf() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4307,7 +4307,7 @@ fn test_48ccbb2888a0739e3724192c28268f97491d807c5943b595384c3efa() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4315,7 +4315,7 @@ fn test_48ccbb2888a0739e3724192c28268f97491d807c5943b595384c3efa() {
 }
 
 #[test]
-fn test_152111b7c04892e7d7af6e3899fe3c2ce4a9be5e4d7eb098754304c4() {
+fn test_b2e09f2a3ed0972ecf0bdb1394b590891b3c28404c1191e63a5307a9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4330,7 +4330,7 @@ fn test_152111b7c04892e7d7af6e3899fe3c2ce4a9be5e4d7eb098754304c4() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4338,7 +4338,7 @@ fn test_152111b7c04892e7d7af6e3899fe3c2ce4a9be5e4d7eb098754304c4() {
 }
 
 #[test]
-fn test_05ceda276d1ec4e67e1a1eea60a7ffd677f388bb35afffcbf9457bfc() {
+fn test_b98ec6df773bb21e0c060913b69cf62345dec1a60e1fc2f8ee85bee9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4353,7 +4353,7 @@ fn test_05ceda276d1ec4e67e1a1eea60a7ffd677f388bb35afffcbf9457bfc() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4361,7 +4361,7 @@ fn test_05ceda276d1ec4e67e1a1eea60a7ffd677f388bb35afffcbf9457bfc() {
 }
 
 #[test]
-fn test_d6eeeafaaf22846ebbb4ab3a52e16f9ec45d97dcb79c465be557af9c() {
+fn test_3dca3e56f11d91615351d2140f58ffa9a78b710cb5b333debf88a2e6() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4376,7 +4376,7 @@ fn test_d6eeeafaaf22846ebbb4ab3a52e16f9ec45d97dcb79c465be557af9c() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 1usize, 0usize]);
@@ -4384,7 +4384,7 @@ fn test_d6eeeafaaf22846ebbb4ab3a52e16f9ec45d97dcb79c465be557af9c() {
 }
 
 #[test]
-fn test_4aedc8297096d3cbf3ba1f92b60ece1817adbcff86b02a2f615b47f0() {
+fn test_6397f3c05f1f81dd29cdc60722e40a1757e3b597c70ceb7892d38ff9() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4399,12 +4399,12 @@ fn test_4aedc8297096d3cbf3ba1f92b60ece1817adbcff86b02a2f615b47f0() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_88c65e0880222a77a6081b56b91a328bce58c56a078f7390e812deb6() {
+fn test_bdc1818c4128642310cc444d854119e248c7dbdfc441b739841bafe8() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4420,7 +4420,7 @@ fn test_88c65e0880222a77a6081b56b91a328bce58c56a078f7390e812deb6() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4428,7 +4428,7 @@ fn test_88c65e0880222a77a6081b56b91a328bce58c56a078f7390e812deb6() {
 }
 
 #[test]
-fn test_7f7930febf1a953e9a16209214df24b1e25668fef6646e4ba73a0362() {
+fn test_1661b19ff8e3e557961d0726a5fc52562be88f81857936b658d8990a() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4444,7 +4444,7 @@ fn test_7f7930febf1a953e9a16209214df24b1e25668fef6646e4ba73a0362() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4452,7 +4452,7 @@ fn test_7f7930febf1a953e9a16209214df24b1e25668fef6646e4ba73a0362() {
 }
 
 #[test]
-fn test_6a812937b162594ae6d2e7186838bee58007fe0565ea13d1ad120fad() {
+fn test_8fb5b0a784b85027efe2db42a4aabb3f005de958f5ce277d50695394() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4468,7 +4468,7 @@ fn test_6a812937b162594ae6d2e7186838bee58007fe0565ea13d1ad120fad() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4476,7 +4476,7 @@ fn test_6a812937b162594ae6d2e7186838bee58007fe0565ea13d1ad120fad() {
 }
 
 #[test]
-fn test_c63bffe550c4ccc0a2e22ba7376915c8fdb3b5ea4cefc35d5fe645e1() {
+fn test_f45b50ec09fdd24cca12480139a4deebe37dc4c4c2170394dc573e91() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4492,7 +4492,7 @@ fn test_c63bffe550c4ccc0a2e22ba7376915c8fdb3b5ea4cefc35d5fe645e1() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4500,7 +4500,7 @@ fn test_c63bffe550c4ccc0a2e22ba7376915c8fdb3b5ea4cefc35d5fe645e1() {
 }
 
 #[test]
-fn test_d98154113ad984467223c941198bb907e66d4317ca462332dcc65a3a() {
+fn test_716b2fa13881778351537e9c4123e6567e3d11eb591c63dd7d691aee() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4515,12 +4515,12 @@ fn test_d98154113ad984467223c941198bb907e66d4317ca462332dcc65a3a() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }
 
 #[test]
-fn test_554c80ccc267415f7cf500e65eb4a6113ee70029b044b06e433cd1c1() {
+fn test_dc9412453869cba39223365b3832978f07d179ff42f5c6ade9bf182e() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4536,7 +4536,7 @@ fn test_554c80ccc267415f7cf500e65eb4a6113ee70029b044b06e433cd1c1() {
             &[100u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4544,7 +4544,7 @@ fn test_554c80ccc267415f7cf500e65eb4a6113ee70029b044b06e433cd1c1() {
 }
 
 #[test]
-fn test_2c048eebcf3d97292e8f48939bb99df29588d8ef7cb76ecf0ae8612c() {
+fn test_e5c8e45e5a425993546ba298f22a19f97d59038bdce0ed68a4f5ec57() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4560,7 +4560,7 @@ fn test_2c048eebcf3d97292e8f48939bb99df29588d8ef7cb76ecf0ae8612c() {
             &[99u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4568,7 +4568,7 @@ fn test_2c048eebcf3d97292e8f48939bb99df29588d8ef7cb76ecf0ae8612c() {
 }
 
 #[test]
-fn test_ba48c5ef5f088e1ffe2f87f9b9bff014d1b6b734bc2180ee57aa41c0() {
+fn test_91bd486eac76569cc5e2d065f678f3be54c0c6323e4f4f2923ec9d01() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4584,7 +4584,7 @@ fn test_ba48c5ef5f088e1ffe2f87f9b9bff014d1b6b734bc2180ee57aa41c0() {
             &[121u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4592,7 +4592,7 @@ fn test_ba48c5ef5f088e1ffe2f87f9b9bff014d1b6b734bc2180ee57aa41c0() {
 }
 
 #[test]
-fn test_44d54d8133ebf73a83c7e6a0b7624efdfb731995e4bcf9b6d06accee() {
+fn test_9c86e3f4ef97dd61358cf6a58949ac0ddbdc415af9e909161642ccdf() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4608,7 +4608,7 @@ fn test_44d54d8133ebf73a83c7e6a0b7624efdfb731995e4bcf9b6d06accee() {
             &[103u8, 126u8][..],
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize, 1usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.langle, [0usize, 1usize, 1usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
     assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
@@ -4616,7 +4616,7 @@ fn test_44d54d8133ebf73a83c7e6a0b7624efdfb731995e4bcf9b6d06accee() {
 }
 
 #[test]
-fn test_d3d81f9ecdc9ef5e728f727285133b79076050e8c6a85801a4791d1b() {
+fn test_866d6c41c9f83bd0365934c1411f4263c2de1077c1305e4db4083770() {
     #[allow(unused_mut)]
     let mut wm = WordMotion::new(
         Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
@@ -4631,6 +4631,379 @@ fn test_d3d81f9ecdc9ef5e728f727285133b79076050e8c6a85801a4791d1b() {
             0u64,
         )
         .unwrap();
-    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize, 5usize]);
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+}
+
+#[test]
+fn test_d23ef0dcfefcffd8c169aa1538b1b4fc5e628d714e845c10534de0ed() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_15c1c12bf544e60c7b5ce6b60cfd9ada5b5324807f57fca40864731d() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_8665baa1f140f32841a8ba0df76134ec7b9819cae86153a22161ae2d() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_0dfac80ebf82a76046f65e74d2d2a409a7b8f4cfe1099af744e4e3d4() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 4usize, 0usize, 4usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 4usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_68c9e1c93efe92315a3080c80f622918034d9d890021dfefbd83059b() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[49u8,][..]);
+}
+
+#[test]
+fn test_86a5f2426bd6ec1aaff620ac4d1581d5d63ded4a9b5276a4f087e6af() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_cce5173b5929e88dc5779a1afdd9c33f8fa9f12b6c1c392bb4edebec() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_acd386c78e0d1fe690dfb8e60797a8410b091d64898bcdf27ed01e9c() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_7574e301eb53b8bd441f894bf9601019aeb5cebf27a9612dd6d87ded() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[std::str::from_utf8(&[97u8, 98u8, 99u8, 100u8, 101u8][..])
+                .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 5usize, 0usize, 5usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 5usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_e4701c405157aa2ddb5144b4a67620453adbdd69677e1079c24650a2() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[49u8,][..]);
+}
+
+#[test]
+fn test_638c753326c00b29253ef5263bd51ca4a91ee08578e7f2490f713892() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[100u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_2c971e5aefcf371827f27eedd9094870d228ec7584ec422297bc31ea() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[99u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_827b5d25cf4c97ca3aba5749af662e802fe85164ee062fdeee3aa982() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[121u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_1f4244ef1dc76da467c59a7b26de580d8e9f6b65fecf48e8a4ed6b69() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .omap(
+            &[
+                std::str::from_utf8(
+                    &[97u8, 98u8, 99u8, 100u8, 101u8, 32u8][..],
+                )
+                .unwrap(),
+            ][..],
+            &[119u8][..],
+            [0usize, 1usize, 6usize, 0usize, 6usize],
+            0u64,
+            &[103u8, 126u8][..],
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.langle, [0usize, 1usize, 6usize, 0usize]);
+    assert_eq!(output.prevent_change, &[48u8,][..]);
+    assert_eq!(output.rangle, [0usize, 1usize, 7usize, 0usize]);
+    assert_eq!(output.visualmode, &[118u8,][..]);
+}
+
+#[test]
+fn test_d4dbfdba4fa441106899d80aa34bfb0f4cfc495c33dd885d0d2d1db7() {
+    #[allow(unused_mut)]
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let output = wm
+        .nmap(
+            &[std::str::from_utf8(
+                &[
+                    97u8, 98u8, 99u8, 32u8, 32u8, 32u8, 32u8, 100u8, 101u8,
+                    102u8,
+                ][..],
+            )
+            .unwrap()][..],
+            &[119u8][..],
+            [0usize, 1usize, 1usize, 0usize, 1usize],
+            0u64,
+        )
+        .unwrap();
+    assert_eq!(output.cursor, [0usize, 1usize, 8usize, 0usize]);
     assert_eq!(output.prevent_change, &[48u8,][..]);
 }

--- a/rust_backend/jieba_vim_rs_metatest/Cargo.toml
+++ b/rust_backend/jieba_vim_rs_metatest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jieba_vim_rs_metatest"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2024"
 
 [dependencies]

--- a/rust_backend/jieba_vim_rs_metatest/Cargo.toml
+++ b/rust_backend/jieba_vim_rs_metatest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jieba_vim_rs_metatest"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 
 [dependencies]

--- a/rust_backend/jieba_vim_rs_metatest/Cargo.toml
+++ b/rust_backend/jieba_vim_rs_metatest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jieba_vim_rs_metatest"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 
 [dependencies]

--- a/rust_backend/jieba_vim_rs_metatest/src/vimscript_transpiler/bootstrap.rs
+++ b/rust_backend/jieba_vim_rs_metatest/src/vimscript_transpiler/bootstrap.rs
@@ -653,7 +653,7 @@ struct StdState {
     #[serde(default)]
     visual_end: Option<Position>,
     #[serde(default)]
-    cursor: Option<PositionCurswant>,
+    cursor: Option<Position>,
 }
 
 #[derive(Deserialize)]
@@ -663,7 +663,7 @@ struct ModelOutput {
     #[serde(default)]
     rangle: Option<Position>,
     #[serde(default)]
-    cursor: Option<PositionCurswant>,
+    cursor: Option<Position>,
     #[serde(default)]
     visualmode: Option<String>,
     #[serde(default)]
@@ -843,6 +843,24 @@ impl BootstrapTestCaseBlock {
         let reader = BufReader::new(File::open(&buffer_file)?);
         let expected_buffer_after =
             unit_verification::read_as_clean_buffer(reader)?;
+        if expected_buffer_after.iter().any(|s| {
+            s.chars()
+                .any(|c| c == '\t' || Ascii::from_char(c).is_none())
+        }) {
+            return Err(anyhow::anyhow!(
+                "expected buffer_after contains TAB or non-ASCII characters, \
+                which is not supported by current version of bootstrap verification"
+            ));
+        }
+
+        // As expected buffer_after contains only non-TAB ASCIIs, all chars are
+        // of visual width 1, and we can safely set `curswant` to `col`.
+        fn cursor2cursorcurswant(
+            [bufnum, lnum, col, off]: Position,
+        ) -> PositionCurswant {
+            [bufnum, lnum, col, off, col]
+        }
+
         let self_ = std_run.0;
 
         let buffer_file = work_dir.join("buffer");
@@ -884,7 +902,7 @@ impl BootstrapTestCaseBlock {
                     rangle: None,
                     visual_begin: std_state.visual_begin,
                     visual_end: std_state.visual_end,
-                    cursor: std_state.cursor,
+                    cursor: std_state.cursor.map(cursor2cursorcurswant),
                 };
                 let buffer_output = match &self_.editor_mode {
                     UnitEditorMode::Normal
@@ -894,7 +912,7 @@ impl BootstrapTestCaseBlock {
                         rangle: None,
                         visual_begin: None,
                         visual_end: None,
-                        cursor: model_output.cursor,
+                        cursor: model_output.cursor.map(cursor2cursorcurswant),
                     },
                     UnitEditorMode::VisualChar
                     | UnitEditorMode::VisualLine

--- a/rust_backend/jieba_vim_rs_metatest/src/vimscript_transpiler/bootstrap.rs
+++ b/rust_backend/jieba_vim_rs_metatest/src/vimscript_transpiler/bootstrap.rs
@@ -920,10 +920,10 @@ impl BootstrapTestCaseBlock {
                 };
                 let mut model_output_items = Vec::new();
                 if model_output.cursor.is_some() {
-                    // We assume cursor to be a 5-tuple of numbers (w/
+                    // We assume cursor to be a 4-tuple of numbers (w/out
                     // curswant) for simplicity, which also matches current
                     // implementation.
-                    model_output_items.push(ModelOutputItem::CursorCurswant);
+                    model_output_items.push(ModelOutputItem::Cursor);
                 }
                 if model_output.langle.is_some() {
                     model_output_items.push(ModelOutputItem::Langle);

--- a/rust_backend/jieba_vim_rs_metatest/src/vimscript_transpiler/bootstrap.rs
+++ b/rust_backend/jieba_vim_rs_metatest/src/vimscript_transpiler/bootstrap.rs
@@ -653,7 +653,7 @@ struct StdState {
     #[serde(default)]
     visual_end: Option<Position>,
     #[serde(default)]
-    cursor: Option<Position>,
+    cursor: Option<PositionCurswant>,
 }
 
 #[derive(Deserialize)]
@@ -902,7 +902,7 @@ impl BootstrapTestCaseBlock {
                     rangle: None,
                     visual_begin: std_state.visual_begin,
                     visual_end: std_state.visual_end,
-                    cursor: std_state.cursor.map(cursor2cursorcurswant),
+                    cursor: std_state.cursor,
                 };
                 let buffer_output = match &self_.editor_mode {
                     UnitEditorMode::Normal

--- a/rust_backend/jieba_vim_rs_metatest/src/vimscript_transpiler/bootstrap.rs
+++ b/rust_backend/jieba_vim_rs_metatest/src/vimscript_transpiler/bootstrap.rs
@@ -847,10 +847,10 @@ impl BootstrapTestCaseBlock {
             s.chars()
                 .any(|c| c == '\t' || Ascii::from_char(c).is_none())
         }) {
-            return Err(anyhow::anyhow!(
+            panic!(
                 "expected buffer_after contains TAB or non-ASCII characters, \
                 which is not supported by current version of bootstrap verification"
-            ));
+            );
         }
 
         // As expected buffer_after contains only non-TAB ASCIIs, all chars are
@@ -1052,12 +1052,10 @@ impl Cli {
                 let old_hash = c.fix_hash_id();
                 let fixed_hash = c.hash_id();
                 if fixed_hash != &old_hash {
-                    return Err(anyhow::anyhow!(
+                    panic!(
                         "parsing failed: {}:{}: new hash = {}",
-                        fixed_hash.file,
-                        fixed_hash.lineno,
-                        fixed_hash.id
-                    ));
+                        fixed_hash.file, fixed_hash.lineno, fixed_hash.id
+                    );
                 }
                 match &fixed_hash.id {
                     TestHashId::Sha2(bytes) => {

--- a/rust_backend/src/wrappers.rs
+++ b/rust_backend/src/wrappers.rs
@@ -97,8 +97,8 @@ impl<'py> IntoPyObject<'py> for NmapOutputWrapper {
         py: Python<'py>,
     ) -> Result<Self::Output, Self::Error> {
         let dict = PyDict::new(py);
-        let [a, b, c, d, e] = self.0.cursor;
-        dict.set_item("cursor", vec![a, b, c, d, e])?;
+        let [a, b, c, d] = self.0.cursor;
+        dict.set_item("cursor", vec![a, b, c, d])?;
         dict.set_item("prevent_change", self.0.prevent_change)?;
         Ok(dict)
     }
@@ -138,10 +138,10 @@ impl<'py> IntoPyObject<'py> for OmapOutputWrapper {
         py: Python<'py>,
     ) -> Result<Self::Output, Self::Error> {
         let dict = PyDict::new(py);
-        let [a, b, c, d, e] = self.0.cursor;
+        let [a, b, c, d] = self.0.cursor;
         let [la, lb, lc, ld] = self.0.langle;
         let [ra, rb, rc, rd] = self.0.rangle;
-        dict.set_item("cursor", vec![a, b, c, d, e])?;
+        dict.set_item("cursor", vec![a, b, c, d])?;
         dict.set_item("langle", vec![la, lb, lc, ld])?;
         dict.set_item("rangle", vec![ra, rb, rc, rd])?;
         dict.set_item("prevent_change", self.0.prevent_change)?;
@@ -296,7 +296,7 @@ impl WordMotionWrapper {
             |b, (lnum, col)| {
                 let output =
                     self.wm.nmap(b, motion, [0, lnum, col, 0, col], 1)?;
-                let [_, lnum, col, _, _] = output.cursor;
+                let [_, lnum, col, _] = output.cursor;
                 Ok((lnum, col))
             },
             &BoundWrapper(buffer),
@@ -447,7 +447,7 @@ impl LazyWordMotionWrapper {
             |b, (lnum, col)| {
                 let output =
                     self.wm.nmap(b, motion, [0, lnum, col, 0, col], 1)?;
-                let [_, lnum, col, _, _] = output.cursor;
+                let [_, lnum, col, _] = output.cursor;
                 Ok((lnum, col))
             },
             &BoundWrapper(buffer),

--- a/test/cases/bootstrapped/nvim_v0.11.5_py311.jieba_test_case
+++ b/test/cases/bootstrapped/nvim_v0.11.5_py311.jieba_test_case
@@ -2,265 +2,454 @@
 
 ?has:nvim
 
-H ce8febe9df4a357be1b3bd79b05133b26b21bb47bafcc820ebca2b51
+H 95649317eb585c559ad8386aaac4ae2a7f8a3856426550d028b130a6
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 |␊
 Bo |␊
 B1 |␊
 
-H 3d2f8c4d5c2018fe7c244fe3c59f7e9b615f1025ce13c7f94c665250
+H 3b4ae9f1b528d423ae8963133cef63321538d01ad34a1caa4ebe03f9
 X u
 M o
 K w
 O d
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H fb5e235846ebb5408fc87eb56231a559d8577cafd0b38b44029b0b19
+H 5c75393b2ef4045dd42efa365a1f171b50cfbc538e13d0204fbd9eb6
 X u
 M o
 K w
 O c
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H 1395313c1f2471b89b1d89ff154168bf5e4af6b574b8f0de1cd3ae40
+H 64d71eea8eab213bb976f1d989309f66bf5a5b61372236a53498a927
 X u
 M o
 K w
 O y
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H bc170f091cd4dd908bdff4fe12c0765083375e143f8cad24e53cf85e
+H 45950b9735f1c99d92a1ebfca666fe2c1456eec12bc0178056f38391
 X u
 M o
 K w
 O g~
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H 5d3794892614cde77fc5d5d3953b37bfce5cacf46019472f29ea95c5
+H b4b63b3556cd1fa007f4ec709bd4d9de6a22471caa7edc91b6305da8
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 |\␊
 Bo |␊
 B1 |␊
 
-H fb557ac4f6aab70b0a7c4cba817420bf042c4987c8715d577848d41d
+H 5494fee08eea7981eee7de1f67198e3f7dd34c81d5756418433ad7a4
 X u
 M o
 K w
 O d
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |\␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H 73f62b80718f82a3f388dff5339f302d78f66b53e38ec8e6c1b8ec40
+H 55ad8aa61160176b4777ae5ba53985090add0da68f85c37bc320dd9f
 X u
 M o
 K w
 O c
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |\␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H 962474a8d396fc7d0f37d9f3c1a761687107f50f9d3b606e4071d801
+H a2ca5aaedc620f7b00a0383f2ecc6657eda3014407cb1c5ae66fbddf
 X u
 M o
 K w
 O y
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |\␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H c99659991170cc57a618f937988c9f82b25b3cdd0988ccad71e51c09
+H 83ccdbbf9807dd1480983d040b2b81bc07068b06d477f02b703d8955
 X u
 M o
 K w
 O g~
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |\␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H f4e52c2049b86b05e8914bac7687beb9510e553c0b3aec0d506c69e3
+H 1232e5a959fa58b32d1b0e6b147f5739e332b5c0499e21f0dbb93968
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 |abcde␊
 Bo abcd|e␊
 B1 abcd|e␊
 
-H bfc5e22ca2d291d5c13f4c87eaa8a5356eba837828f3d6abc009c2fb
+H 52f5873e79e7244d97482854e3f55bd55d64db39a8bf767342de3d4b
 X u
 M o
 K w
 O d
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde␊
 Bp <abcde>␊
 Bo |␊
 B1 |␊
 
-H 1a76649c6f7df4b7b26b414ca2648fb2784ebd38917337d49d03cae7
+H 80e808659787dcdaebcc66e723bae56eec6cd5f7e052433e20c3c5a3
 X u
 M o
 K w
 O c
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde␊
 Bp <abcde>␊
 Bo |␊
 B1 |␊
 
-H 693a30ae021128704e357b41fa452acafdd043a8b0f8a5ed11833dcf
+H 3ac4e49b96f591c64f5f678bf0c5c3bf1f85f3c45fc17e50d1f7c99a
 X u
 M o
 K w
 O y
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde␊
 Bp <abcde>␊
 Bo |abcde␊
 B1 |abcde␊
 
-H 108e60bf8c518e15aec760e5ded985626e3766b50d0e3e02def73d29
+H 097f3b52c20d23b90bbaa0eca9476caf1ef80325bb3895a43b64cb59
 X u
 M o
 K w
 O g~
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde␊
 Bp <abcde>␊
 Bo |ABCDE␊
 B1 |ABCDE␊
 
-H d79f0c071d66d4a46182372ff56e55951199f31006f623230237d567
+H 52bc5c52d1d29e812e20697130033c6e6bd1afc573a78ea85d61d790
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 |abcde\␊
 Bo abcd|e␊
 B1 abcd|e␊
 
-H 4bd15592fedf02f774998db6dfbc9e92bdb54d669d9722bf60f3ae05
+H b390ceadac601ac21217a9e177a8c69067428d82d1f32c8ad7013fa8
 X u
 M o
 K w
 O d
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde\␊
 Bp <abcde>␊
 Bo |␊
 B1 |␊
 
-H 9dbb05856bcba0b5e92f5c1a2c29892a86e3b986aa15b8a0bb5e7ade
+H 829b2d40486beb222742cf61169e947ba33048a0d03beb0a08fced05
 X u
 M o
 K w
 O c
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde\␊
 Bp <abcde>␊
 Bo |␊
 B1 |␊
 
-H 581cf81573afa927a815f8b92b6cc55d761635b928828594830f94db
+H df4bd5abac9651056fae31ce8cd90c6b3e3bdf06f10e957aff4f5b43
 X u
 M o
 K w
 O y
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde\␊
 Bp <abcde>␊
 Bo |abcde␊
 B1 |abcde␊
 
-H 5500337756cdfcb86b417f834d9c7e52267e5f810076199bf7541366
+H df72ec8230b00071f43a797c51c6081c23cdc2ceed79baab5405016f
 X u
 M o
 K w
 O g~
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde\␊
 Bp <abcde>␊
 Bo |ABCDE␊
 B1 |ABCDE␊
 
-H be3ab94b7c9794c8ce63979fc3dc0fc519704fc29522c104fa1061db
+H 225462ea5425878e213d72cb77ef39859acf053bd1b5803057f2bed8
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 abc|de␊
 Bo abcd|e␊
 B1 abcd|e␊
+
+H 061da9c720104ca623958ae278fc286b8b29cfa7d44048fce15b7a30
+X u
+M o
+K w
+O d
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abc|de␊
+Bp abc<de>␊
+Bo abc|␊
+B1 ab|c␊
+
+H d1214951e79590bf246f9ccd4efe5b35168f270d44f7424b6a6776e5
+X u
+M o
+K w
+O c
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abc|de␊
+Bp abc<de>␊
+Bo abc|␊
+B1 ab|c␊
+
+H c5edf4253c0d257865d5b9f791117a697794950a5749b6abc1e2f65f
+X u
+M o
+K w
+O y
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abc|de␊
+Bp abc<de>␊
+Bo abc|de␊
+B1 abc|de␊
+
+H 3626fd483a120b9212e2f477d573660874b8ee374640138613f53c6e
+X u
+M o
+K w
+O g~
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abc|de␊
+Bp abc<de>␊
+Bo abc|DE␊
+B1 abc|DE␊
+
+H 34786789639d2832beddaa52041f9f9beab2c1bab2e463cc1066b31a
+X u
+M n
+K w
+R "
+C 0
+Q | prevent_change=1
+B0 abcd|e␊
+Bo abcd|e␊
+B1 abcd|e␊
+
+H 98adcbc49b54bf9b8c1c57342c6f2ed405f8bd049d6565d6c1909fc0
+X u
+M o
+K w
+O d
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcd|e␊
+Bp abcd<e>␊
+Bo abcd|␊
+B1 abc|d␊
+
+H 30209a5be2983ce24d3a865fc6a1e672079d3c10a08b771b91ef3b08
+X u
+M o
+K w
+O c
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcd|e␊
+Bp abcd<e>␊
+Bo abcd|␊
+B1 abc|d␊
+
+H 58138e08422217b5f1add492866f46a4b092bb9307a6741c0a27baa2
+X u
+M o
+K w
+O y
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcd|e␊
+Bp abcd<e>␊
+Bo abcd|e␊
+B1 abcd|e␊
+
+H d5755cc95aa591c3c2b4364d8b57089a2deba1dc718b19db5f1866bc
+X u
+M o
+K w
+O g~
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcd|e␊
+Bp abcd<e>␊
+Bo abcd|E␊
+B1 abcd|E␊
+
+H 5ddb9c34aef49344827ab1f543b72ff291b70c0852ae96c8f4d60025
+X u
+M n
+K w
+R "
+C 0
+Q | prevent_change=1
+B0 abcde|·␊
+Bo abcde|·␊
+B1 abcde|·␊
+
+H fa205b7f7bae5c6b292c7242e9974a48c179228356d551449cafdb3c
+X u
+M o
+K w
+O d
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcde|·␊
+Bp abcde<·>␊
+Bo abcde|␊
+B1 abcd|e␊
+
+H fa4d59fbef8c9fcb4f254e83c9407a1409512734808d2f460175485e
+X u
+M o
+K w
+O c
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcde|·␊
+Bp abcde<·>␊
+Bo abcde|␊
+B1 abcd|e␊
+
+H c8fef4f0ae8b45e944fa64d6c664b325c557f059737750f541733947
+X u
+M o
+K w
+O y
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcde|·␊
+Bp abcde<·>␊
+Bo abcde|·␊
+B1 abcde|·␊
+
+H 25ddd8699f5d7467ffde4c6e8b10c03963eaf6f902db9e4c3cd569c3
+X u
+M o
+K w
+O g~
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcde|·␊
+Bp abcde<·>␊
+Bo abcde|·␊
+B1 abcde|·␊
+
+H 29fb98e8f4b9e8132988a71a4e26432ea130d3dc95e34b1fed5436c5
+X u
+M n
+K w
+R "
+C 0
+Q | prevent_change=0
+B0 |abc····def␊
+Bo abc····|def␊
+B1 abc····|def␊

--- a/test/cases/bootstrapped/vim_v9.1.0000_py311.jieba_test_case
+++ b/test/cases/bootstrapped/vim_v9.1.0000_py311.jieba_test_case
@@ -2,265 +2,454 @@
 
 ?!has:nvim
 
-H a992ffad30994ab1b69d9c8e9a9a1a5f534611609625ec35c23f30e1
+H 807d45a97423b9a26ad8e521ae3af6af6e486e6182f2bff0ed940896
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 |␊
 Bo |␊
 B1 |␊
 
-H eefce73591308c046661dfbaf4c805dd3c5404adb1fafa572970d2e8
+H ab0aae06b3494ea64cbeaf534532adc26076748b2b5f51b6907d6fed
 X u
 M o
 K w
 O d
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H b38a46fe201eb488600338b76007705fe4a16ab4b09164d302d50e00
+H 7a08e780d59ca162920720140d6eac0298d5602103bb4f4267bd7bba
 X u
 M o
 K w
 O c
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H a1ef97f8339c88caf98baef20780168689c855c926fa04377201efd0
+H ac7de5b56c38b27cada9e53a08c555f099cf086f70553eb82317c02a
 X u
 M o
 K w
 O y
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H 4f1a357464eca09a6939bb40085ec6cb52ec80f439fc6262e540d913
+H f05af16087f08376d4ff0b9037efa5d87617c337d034f509aee05020
 X u
 M o
 K w
 O g~
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H eccea143a32d69b022bd86407f61f2da3591283e849dbd0e250653f3
+H 70c7c0c7062fea40144b1df3c438c1a6800a36360c847fad5f325090
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 |\␊
 Bo |␊
 B1 |␊
 
-H 48ccbb2888a0739e3724192c28268f97491d807c5943b595384c3efa
+H b90575a32700f6f9ad2d28e5b75dc02168316454d79d2bdfd5adbebf
 X u
 M o
 K w
 O d
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |\␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H 152111b7c04892e7d7af6e3899fe3c2ce4a9be5e4d7eb098754304c4
+H b2e09f2a3ed0972ecf0bdb1394b590891b3c28404c1191e63a5307a9
 X u
 M o
 K w
 O c
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |\␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H 05ceda276d1ec4e67e1a1eea60a7ffd677f388bb35afffcbf9457bfc
+H b98ec6df773bb21e0c060913b69cf62345dec1a60e1fc2f8ee85bee9
 X u
 M o
 K w
 O y
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |\␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H d6eeeafaaf22846ebbb4ab3a52e16f9ec45d97dcb79c465be557af9c
+H 3dca3e56f11d91615351d2140f58ffa9a78b710cb5b333debf88a2e6
 X u
 M o
 K w
 O g~
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |\␊
 Bp <>␊
 Bo |␊
 B1 |␊
 
-H 4aedc8297096d3cbf3ba1f92b60ece1817adbcff86b02a2f615b47f0
+H 6397f3c05f1f81dd29cdc60722e40a1757e3b597c70ceb7892d38ff9
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 |abcde␊
 Bo abcd|e␊
 B1 abcd|e␊
 
-H 88c65e0880222a77a6081b56b91a328bce58c56a078f7390e812deb6
+H bdc1818c4128642310cc444d854119e248c7dbdfc441b739841bafe8
 X u
 M o
 K w
 O d
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde␊
 Bp <abcde>␊
 Bo |␊
 B1 |␊
 
-H 7f7930febf1a953e9a16209214df24b1e25668fef6646e4ba73a0362
+H 1661b19ff8e3e557961d0726a5fc52562be88f81857936b658d8990a
 X u
 M o
 K w
 O c
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde␊
 Bp <abcde>␊
 Bo |␊
 B1 |␊
 
-H 6a812937b162594ae6d2e7186838bee58007fe0565ea13d1ad120fad
+H 8fb5b0a784b85027efe2db42a4aabb3f005de958f5ce277d50695394
 X u
 M o
 K w
 O y
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde␊
 Bp <abcde>␊
 Bo |abcde␊
 B1 |abcde␊
 
-H c63bffe550c4ccc0a2e22ba7376915c8fdb3b5ea4cefc35d5fe645e1
+H f45b50ec09fdd24cca12480139a4deebe37dc4c4c2170394dc573e91
 X u
 M o
 K w
 O g~
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde␊
 Bp <abcde>␊
 Bo |ABCDE␊
 B1 |ABCDE␊
 
-H d98154113ad984467223c941198bb907e66d4317ca462332dcc65a3a
+H 716b2fa13881778351537e9c4123e6567e3d11eb591c63dd7d691aee
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 |abcde\␊
 Bo abcd|e␊
 B1 abcd|e␊
 
-H 554c80ccc267415f7cf500e65eb4a6113ee70029b044b06e433cd1c1
+H dc9412453869cba39223365b3832978f07d179ff42f5c6ade9bf182e
 X u
 M o
 K w
 O d
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde\␊
 Bp <abcde>␊
 Bo |␊
 B1 |␊
 
-H 2c048eebcf3d97292e8f48939bb99df29588d8ef7cb76ecf0ae8612c
+H e5c8e45e5a425993546ba298f22a19f97d59038bdce0ed68a4f5ec57
 X u
 M o
 K w
 O c
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde\␊
 Bp <abcde>␊
 Bo |␊
 B1 |␊
 
-H ba48c5ef5f088e1ffe2f87f9b9bff014d1b6b734bc2180ee57aa41c0
+H 91bd486eac76569cc5e2d065f678f3be54c0c6323e4f4f2923ec9d01
 X u
 M o
 K w
 O y
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde\␊
 Bp <abcde>␊
 Bo |abcde␊
 B1 |abcde␊
 
-H 44d54d8133ebf73a83c7e6a0b7624efdfb731995e4bcf9b6d06accee
+H 9c86e3f4ef97dd61358cf6a58949ac0ddbdc415af9e909161642ccdf
 X u
 M o
 K w
 O g~
 R "
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 B0 |abcde\␊
 Bp <abcde>␊
 Bo |ABCDE␊
 B1 |ABCDE␊
 
-H d3d81f9ecdc9ef5e728f727285133b79076050e8c6a85801a4791d1b
+H 866d6c41c9f83bd0365934c1411f4263c2de1077c1305e4db4083770
 X u
 M n
 K w
 R "
 C 0
-Q | \ prevent_change=0
+Q | prevent_change=0
 B0 abc|de␊
 Bo abcd|e␊
 B1 abcd|e␊
+
+H d23ef0dcfefcffd8c169aa1538b1b4fc5e628d714e845c10534de0ed
+X u
+M o
+K w
+O d
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abc|de␊
+Bp abc<de>␊
+Bo abc|␊
+B1 ab|c␊
+
+H 15c1c12bf544e60c7b5ce6b60cfd9ada5b5324807f57fca40864731d
+X u
+M o
+K w
+O c
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abc|de␊
+Bp abc<de>␊
+Bo abc|␊
+B1 ab|c␊
+
+H 8665baa1f140f32841a8ba0df76134ec7b9819cae86153a22161ae2d
+X u
+M o
+K w
+O y
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abc|de␊
+Bp abc<de>␊
+Bo abc|de␊
+B1 abc|de␊
+
+H 0dfac80ebf82a76046f65e74d2d2a409a7b8f4cfe1099af744e4e3d4
+X u
+M o
+K w
+O g~
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abc|de␊
+Bp abc<de>␊
+Bo abc|DE␊
+B1 abc|DE␊
+
+H 68c9e1c93efe92315a3080c80f622918034d9d890021dfefbd83059b
+X u
+M n
+K w
+R "
+C 0
+Q | prevent_change=1
+B0 abcd|e␊
+Bo abcd|e␊
+B1 abcd|e␊
+
+H 86a5f2426bd6ec1aaff620ac4d1581d5d63ded4a9b5276a4f087e6af
+X u
+M o
+K w
+O d
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcd|e␊
+Bp abcd<e>␊
+Bo abcd|␊
+B1 abc|d␊
+
+H cce5173b5929e88dc5779a1afdd9c33f8fa9f12b6c1c392bb4edebec
+X u
+M o
+K w
+O c
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcd|e␊
+Bp abcd<e>␊
+Bo abcd|␊
+B1 abc|d␊
+
+H acd386c78e0d1fe690dfb8e60797a8410b091d64898bcdf27ed01e9c
+X u
+M o
+K w
+O y
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcd|e␊
+Bp abcd<e>␊
+Bo abcd|e␊
+B1 abcd|e␊
+
+H 7574e301eb53b8bd441f894bf9601019aeb5cebf27a9612dd6d87ded
+X u
+M o
+K w
+O g~
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcd|e␊
+Bp abcd<e>␊
+Bo abcd|E␊
+B1 abcd|E␊
+
+H e4701c405157aa2ddb5144b4a67620453adbdd69677e1079c24650a2
+X u
+M n
+K w
+R "
+C 0
+Q | prevent_change=1
+B0 abcde|·␊
+Bo abcde|·␊
+B1 abcde|·␊
+
+H 638c753326c00b29253ef5263bd51ca4a91ee08578e7f2490f713892
+X u
+M o
+K w
+O d
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcde|·␊
+Bp abcde<·>␊
+Bo abcde|␊
+B1 abcd|e␊
+
+H 2c971e5aefcf371827f27eedd9094870d228ec7584ec422297bc31ea
+X u
+M o
+K w
+O c
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcde|·␊
+Bp abcde<·>␊
+Bo abcde|␊
+B1 abcd|e␊
+
+H 827b5d25cf4c97ca3aba5749af662e802fe85164ee062fdeee3aa982
+X u
+M o
+K w
+O y
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcde|·␊
+Bp abcde<·>␊
+Bo abcde|·␊
+B1 abcde|·␊
+
+H 1f4244ef1dc76da467c59a7b26de580d8e9f6b65fecf48e8a4ed6b69
+X u
+M o
+K w
+O g~
+R "
+C 0
+Q | < > prevent_change=0 visualmode=v
+B0 abcde|·␊
+Bp abcde<·>␊
+Bo abcde|·␊
+B1 abcde|·␊
+
+H d4dbfdba4fa441106899d80aa34bfb0f4cfc495c33dd885d0d2d1db7
+X u
+M n
+K w
+R "
+C 0
+Q | prevent_change=0
+B0 |abc····def␊
+Bo abc····|def␊
+B1 abc····|def␊

--- a/test/cases/d-special_nvim.jieba_test_case
+++ b/test/cases/d-special_nvim.jieba_test_case
@@ -31,7 +31,6 @@
 #B0 |␊···abcd␊······␊
 
 H a8d4f7746427a144e38ca1ec7bee2a21d86ab52b7c2f8e1acb26075e
-Q | < > prevent_change=0 visualmode=V
 C 2
 Bp <␊···abcd>␊······␊
 Bo ·····|·␊

--- a/test/cases/d-special_nvim.jieba_test_case
+++ b/test/cases/d-special_nvim.jieba_test_case
@@ -25,13 +25,13 @@
 #K w
 #O d
 #R a
-#Q | \ < > prevent_change=0 visualmode=V
+#Q | < > prevent_change=0 visualmode=V
 
 // Buffer: |␊···abcd␊······␊ <<<
 #B0 |␊···abcd␊······␊
 
-H d348f112e252ae7c657f3b6a6291cc7d7581295e48b56307d2406092
-Q | \ < > prevent_change=0 visualmode=V
+H a8d4f7746427a144e38ca1ec7bee2a21d86ab52b7c2f8e1acb26075e
+Q | < > prevent_change=0 visualmode=V
 C 2
 Bp <␊···abcd>␊······␊
 Bo ·····|·␊

--- a/test/cases/empty.jieba_test_case
+++ b/test/cases/empty.jieba_test_case
@@ -20,25 +20,25 @@
 #X u
 #M n
 #K w
-#Q | \
+#Q |
 
-H 698e57d0555d71c2d35a6b462c2af57b8ff017a14aff967cf1c3afbe
+H c49507d01cdbea465d32314ceb801d9c8f254abc9c6f69815f182df8
 B0 |␊
 Bo |␊
 B1 |␊
 
-H 706d85f12b47c3d525af804374cbc7e241aa86cc95e22e64264096ba
+H 8cce72cc00faa068725a1fe04b88053850a3f2000273e4f4730c6053
 C 1000
 B0 |␊
 Bo |␊
 B1 |␊
 
-H 80079981ca7ca6dd775d356f8d924c607deffc768fa0018f8b12be2a
+H 03a125e3f6590812f466d308ddc74afb24d01987a305b40f4eb8d9b1
 B0 |\␊
 Bo |␊
 B1 |␊
 
-H 8296af34e1f15c6444a53271d4d5f75a7eae56f85b851e01798dca1f
+H 10b646de08ba83ad3a6d33fabcde1c1c5fadc694e8d3a5b4088a3744
 C 1000
 B0 |\␊
 Bo |␊
@@ -50,25 +50,25 @@ B1 |␊
 #X u
 #M n
 #K b
-#Q | \
+#Q |
 
-H 797f49bf8ea25f1bafdb3b8d59477ea2447dfbbd137facedb78198ce
+H 3a6b4a36a2338d2844f0df72ced159c538450f9783bb8b3e0cf9e472
 B0 |␊
 Bo |␊
 B1 |␊
 
-H 7015f41f9bfabaa3bfc6ae2697658484cfee45d53c4341f34edc0f10
+H 329b00bed6a566f63230dff020b2d3c73b5123e211812ddd9f57429b
 C 1000
 B0 |␊
 Bo |␊
 B1 |␊
 
-H c209f30411450c7334ad40b70090d535cb0fa726ee00a3773550a0c5
+H f09570f84730fa18dae7fff574e9d718d9fde747f5cc3fe797069d47
 B0 |\␊
 Bo |␊
 B1 |␊
 
-H 202e4390a90c3411730e2a0c0d8c6684d00266d1e0231de11107d539
+H 4ab46fe2887d1522e96230eccb0894f4adb901a241a5b428612d9b14
 C 1000
 B0 |\␊
 Bo |␊
@@ -80,25 +80,25 @@ B1 |␊
 #X u
 #M n
 #K e
-#Q | \
+#Q |
 
-H 52135bf88ac6b5780b7c45bce3e75aceaff381984bad60d4a07aa516
+H cf51bdeb6cae4ca1d663f0040b03ef23d3364c5f1a5bdb63f7be2b23
 B0 |␊
 Bo |␊
 B1 |␊
 
-H 4c0437ad690881933de761f489767067a0c46e5ae6e6d26e49d4d92c
+H 2e06b3142444ec8d799820b31e62d6d33c60e501e69922c682043f13
 C 1000
 B0 |␊
 Bo |␊
 B1 |␊
 
-H 4122b22abea40181a71e20fd6f0f4fe698b0eb1b43ed678e8cfe19bb
+H a23235e47791c4c2df0c9b13493a3c9832e4caa21cede2dba0b86cd9
 B0 |\␊
 Bo |␊
 B1 |␊
 
-H 1e77aa1259b352d0424c4810c2c06e8210f88200edad7cd574f28425
+H 38600c9b3ad5e0e4ddb5625882bf02c84436780f9a6296e16b2a1de3
 C 1000
 B0 |\␊
 Bo |␊
@@ -110,25 +110,25 @@ B1 |␊
 #X u
 #M n
 #K ge
-#Q | \
+#Q |
 
-H 46f6b57c58a49bc312b67f455da23cf0bcfb9a5b869466586a9a05d0
+H be520fc284952bcd9583f04fa1c63ad706c032517f4df840518cdffc
 B0 |␊
 Bo |␊
 B1 |␊
 
-H d7dd1d63585a4759bdcf74ac3497bf8383aac9be662bf228f908342e
+H a96daab181124c5a19a423777f5aee4ce188f1c837f5b4ee5c9ca04a
 C 1000
 B0 |␊
 Bo |␊
 B1 |␊
 
-H b84918bb3e786c4d846a9e78e010500fea8f291803b6bda22850955b
+H 69aeb41ce405f3b2dcdc586ea6e1aaffcf3630053e14b5bc9fccc7de
 B0 |\␊
 Bo |␊
 B1 |␊
 
-H 6c6aa33a9bc7195ba3f736ebd073cc9fb0106e09465b343f773279b3
+H 1820a6b27c57b06f594755069925c9ac174c225dc6b6d9bc02161bb6
 C 1000
 B0 |\␊
 Bo |␊
@@ -393,9 +393,9 @@ S1 visualmode()=\<C-v>
 #M o
 #K w
 #O d
-#Q | \ < > prevent_change=0 visualmode=v
+#Q | < > prevent_change=0 visualmode=v
 
-H 81795c390b7e7b8a0f8a95b952f4c63241e5c10d7a3b1f3ea80b3bc0 visual mode unchanged
+H 8fb704e4f7569d63dbd32678f9b83a8481299a11154abcbbcd207451 visual mode unchanged
 S0 visualmode()=V
 B0 |[]␊
 Bp <>␊
@@ -403,7 +403,7 @@ Bo |␊
 B1 |[]␊
 S1 visualmode()=V
 
-H d60bad19a6a163309feeab4b814f244a59e505ee593956fe07862824 visual mode unchanged
+H 44a6e532bc15add989567d8b6eda27343830dcb2c32fd2bcc60bf065 visual mode unchanged
 S0 visualmode()=
 B0 |␊
 Bp <>␊

--- a/test/cases/err.jieba_test_case
+++ b/test/cases/err.jieba_test_case
@@ -15,7 +15,7 @@
 // This file contains failed test cases in bootstrap verification.
 // Best viewed in Vim.
 
-H c5fecc2f2d4d97c1080f86aaf0bc1afbba9de6d0b62d0602d802b686
+H c7d2120a5a8abb067dc68f04172115594efb14ab0f3dfb6862dfa154
 X u
 M o
 K w
@@ -23,7 +23,7 @@ O d
 R a
 B0 abc|de␊
 C 0
-Q | \ < > prevent_change=0 visualmode=v
+Q | < > prevent_change=0 visualmode=v
 Bp abc<d>e␊
 Bo ab|c␊
 B1 ab|c␊

--- a/test/cases/odmap_w.jieba_test_case
+++ b/test/cases/odmap_w.jieba_test_case
@@ -22,12 +22,12 @@
 #K w
 #O d
 #R a
-#Q | \ < > prevent_change=0 visualmode=v
+#Q | < > prevent_change=0 visualmode=v
 
 // Buffer: |␊ <<<
 #B0 |␊
 
-H eff464fb67b28ce0d4d2e332574c68f8e34290264f8afdfa46c69058
+H 783df2d6a656f6a846c1023d9b79d7ee219cd804f69b199650dbbf04
 C 1
 Bp <>␊
 Bo |␊
@@ -37,14 +37,14 @@ B1 |␊
 // Buffer: |······␊ <<<
 #B0 |······␊
 
-H d074a9ae8c2d202e384b62a0610dbc75161d574710ecfc68d264303c
+H 0dbae4fbbfcfad38d75785c1a7d576ea33ed736abc7817e6c0e309bd
 C 1
 Bp <·····>·␊
 Bo |␊
 B1 |␊
 S1 "a=\<Space>\<Space>\<Space>\<Space>\<Space>\<Space>
 
-H c420a9092c7354bf89945603bbb9bbcb7b23c85c400e955716253a00
+H 322fd55e5e45035b183d456b8bb0d7e84175b5d4e40f0cc4c0a48231
 C 10293949403
 Bp <·····>·␊
 Bo |␊
@@ -55,7 +55,7 @@ S1 "a=\<Space>\<Space>\<Space>\<Space>\<Space>\<Space>
 // Buffer: ··|····␊ <<<
 #B0 ··|····␊
 
-H 0d8915939e7a875257c545577c6f6be5fd3e47948820bc13e67cdaf8
+H 8a035514a1e16aef0109e47adaf150e82ee3e2967605eb7f3fa4bc73
 C 1
 Bp ··<···>·␊
 Bo ·|·␊
@@ -66,7 +66,7 @@ S1 "a=\<Space>\<Space>\<Space>\<Space>
 // Buffer: |␊␊ <<<
 #B0 |␊␊
 
-H 2e48878e789e89cbdec64e3a7bd94a361733ea7ee438c64178aa83be
+H 1f175043c100f5a93d3b94ea6e2ceb8ad9595171930226d632e3d73c
 C 1
 Bp <>␊␊
 Bo |␊
@@ -77,7 +77,7 @@ S1 "a=\<Newline>
 // Buffer: ··|····␊␊ <<<
 #B0 ··|····␊␊
 
-H f1c8ff7972854262d9ae5b10d6017fbfa44ac7b8e248669d516394a7
+H 743b3c4ea7873f4f78aa00e6be0fc8b982a7dabd9ef75d9ea84ae1a0
 C 1
 Bp ··<···>·␊␊
 Bo ·|·␊␊
@@ -88,7 +88,7 @@ S1 "a=\<Space>\<Space>\<Space>\<Space>
 // Buffer: ··|····␊··␊ <<<
 #B0 ··|····␊··␊
 
-H 1605a5ffa5d509d54f2834587a5dc5116e43aa4526f35f65e54a398c
+H 451e7c72edc394f97556568d81ec6ee9e9d25e8f045fb7b8f791113f
 C 1
 Bp ··<···>·␊··␊
 Bo ·|·␊··␊
@@ -99,7 +99,7 @@ S1 "a=\<Space>\<Space>\<Space>\<Space>
 // Buffer: |␊······␊␊ <<<
 #B0 |␊······␊␊
 
-H 6e70ecf32b14e1c4a111aab8c79d80096e276bc2cb85c670d07ae4ff
+H 95f6c2b8150ec1b2f909fc8bd50ca6f57ca5e5bc237188b42ffa8c06
 C 1
 Bp <>␊······␊␊
 Bo ·····|·␊␊
@@ -110,7 +110,7 @@ S1 "a=\<Newline>
 // Buffer: |␊···abcd␊␊ <<<
 #B0 |␊···abcd␊␊
 
-H 2aaef08602951d1946d055d4174ab56a682bbb3fbefa9100a485f0f6
+H dacd2e355de2ad2cd8c7f8917f82c6a432d9ce87f649a25447615190
 C 1
 Bp <>␊···abcd␊␊
 Bo ···|abcd␊␊
@@ -118,8 +118,8 @@ B1 ···|abcd␊␊
 S1 "a=\<Newline>
 
 // d-special
-H 09a4e1ae715d8a8b657741c2ce71a8620a0a31d62687be7a7411edd6
-Q | \ < > prevent_change=0 visualmode=V
+H 5140fce8366bba565d9e5bd258deae8b35b185073e6ede9308c337c0
+Q | < > prevent_change=0 visualmode=V
 C 2
 Bp <␊···abcd>␊␊
 Bo |␊
@@ -131,8 +131,8 @@ S1 "a=\<Newline>\<Space>\<Space>\<Space>abcd\<Newline>
 #B0 |␊···abcd␊
 
 // d-special
-H 64eaeef8e77814bff15fcb065fcd23ca80eb8b51c1f14efc92e32740
-Q | \ < > prevent_change=0 visualmode=V
+H 3f83629c73bb43a38896d71d28d8c1f703c9eccc95fa0520c5887f8b
+Q | < > prevent_change=0 visualmode=V
 C 2
 Bp <␊···abcd>␊
 Bo |␀
@@ -144,8 +144,8 @@ S1 "a=\<Newline>\<Space>\<Space>\<Space>abcd\<Newline>
 #B0 |␊···abcd␊······␊
 
 // d-special
-H e045074ead88095b110cca6565bde1dc2d981ca9535c2311c425cb80
-Q | \ < > prevent_change=0 visualmode=V
+H 40bc60e2568bebf2ed73174d648d8464a10cba79957124462f01245a
+Q | < > prevent_change=0 visualmode=V
 C 2
 Bp <␊···abcd>␊······␊
 Bo ·····|·␊
@@ -156,7 +156,7 @@ S1 "a=\<Newline>\<Space>\<Space>\<Space>abcd\<Newline>
 // Buffer: |␊···abcd␊······efg␊ <<<
 #B0 |␊···abcd␊······efg␊
 
-H c5b6479f8b77261426ea8846e93f6c532950988647215c0d59571006
+H 2304ebf0caf809b4b1e1ee11db994de530df34d2db7e755b80bd024e
 C 2
 Bp <␊···abcd>␊······efg␊
 Bo ······|efg␊
@@ -167,7 +167,7 @@ S1 "a=\<Newline>\<Space>\<Space>\<Space>abcd\<Newline>
 // Buffer: |␊···abcd␊··␊·␊···efg␊ <<<
 #B0 |␊···abcd␊··␊·␊···efg␊
 
-H ff8e551260f6a64d3825a6055cfc3de7e64a5d87ebefd6ea9f8c044e
+H 213a87b8ef26620353982ee99e728eba8136741c3163d9258027c389
 C 2
 Bp <␊···abcd>␊··␊·␊···efg␊
 Bo ·|·␊·␊···efg␊
@@ -175,8 +175,8 @@ B1 ·|·␊·␊···efg␊
 S1 "a=\<Newline>\<Space>\<Space>\<Space>abcd\<Newline>
 
 // d-special
-H 9376aa7484a2d0775d9ce7286ef702070ad2348562ac6277e44d2dcd
-Q | \ < > prevent_change=0 visualmode=V
+H b993f000f06f1d195e616223a96725c1a405b9dd5c2c04d971aad08d
+Q | < > prevent_change=0 visualmode=V
 C 3
 Bp <␊···abcd␊··␊·␊···efg>␊
 Bo |␀


### PR DESCRIPTION
Known facts about vim cursor position (does not apply to `'<` etc.):

- `col` is the 1-based byte offset.
- `curswant` is the 1-based virtual column number, whose computation is intractable, but `curswant` is always set to the default value after word motion (see below), even for motion failure case.
- `bufnum` is always 0 under word motions.
- `off` is always 0 under word motions.
- By calling `cursor([lnum, col])`, vim automatically sets `bufnum` to zero, `off` to zero and `curswant` to the virtual column of `col` (the default). In contrast, calling `setpos(".", [bufnum, lnum, col, off])` simply leaves `curswant` unchanged, which is usually *not* what we want. Hence, the very original way of manipulating `[lnum, col]` is in fact the most suitable way for cursor positioning so far.
