### PR TITLE
Copy cdylib to pythonx directory in shell build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Plug 'kkew3/jieba.vim', { 'tag': 'v1.0.5', 'do': './build.sh' }
 
 其中 `./build.sh` 用于下载预编译链接库，然后如果没有找到的话再尝试本地编译。
 
+Windows 用户可以把 `'do': './build.sh'` 替换为 `'do': '.\build.ps1'` 以运行 powershell 安装脚本。
+
 虽然通常不需要，但在极少数情况下可能需要进入插件目录调整 `rust_backend/Cargo.toml` 中的 pyo3 python ABI 版本，以匹配 vim 中 python3 的版本。可以在终端使用
 
 ```bash
@@ -150,6 +152,8 @@ Plug 'kkew3/jieba.vim', { 'tag': 'v1.0.5', 'do': './build.sh' }
 
 where `./build.sh` is used to download precompiled shared library.
 Local compilation will be attempted only if the shared library cannot be found.
+
+On Windows, `'do': './build.sh'` can be replaced with `'do': '.\build.ps1'` in order to run the build script in powershell.
 
 Though not always necessary, user may need to adjust the pyo3 python ABI in `rust_backend/Cargo.toml` under the plugin directory after downloading the plugin, in order to match with the python3 version vim is compiled against.
 The vim's python3 version may be checked by the following command at terminal:

--- a/build.ps1
+++ b/build.ps1
@@ -48,10 +48,18 @@ function Download-Release {
 
 function Build-From-Source {
 	$color_when = if ($env:VIMRUNTIME) { 'never' } else { 'auto' }
+	# Assume that build.ps1 only runs on Windows.
+	$cdylib_name = 'jieba_vim_rs.dll'
+	$dest_name = 'jieba_vim_rs.pyd'
 	Push-Location 'rust_backend'
 	try {
-		& cargo build -r -F expose-shared-library --color=$color_when
-		return ($LASTEXITCODE -eq 0)
+		& cargo build -r --color=$color_when
+		if ($LASTEXITCODE -ne 0) { return $false }
+
+		# Remove-Item: used to delete $dest_name in case it's a symlink
+		Remove-Item "..\pythonx\jieba_vim\$dest_name" -Force -ErrorAction SilentlyContinue
+		Copy-Item "target\release\$cdylib_name" -Destination "..\pythonx\jieba_vim\$dest_name"
+		return $?
 	} finally {
 		Pop-Location
 	}
@@ -61,7 +69,7 @@ if (Has-Command git) {
 	if (Download-Release) { exit 0 }
 }
 if (Has-Command cargo) {
-	if (Build-From-Source) { exit 0 } else { exit $LASTEXITCODE }
+	if (Build-From-Source) { exit 0 } else { exit 1 }
 } else {
 	Write-Error 'cargo not found; cannot build from source.'
 	exit 1

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,22 @@ build_from_source() {
     else
         color_when=auto
     fi
-    cd rust_backend && cargo build -r -F expose-shared-library --color=$color_when
+    case "$(uname -s)" in
+        Darwin)
+            cdylib_name=libjieba_vim_rs.dylib
+            dest_name=jieba_vim_rs.so
+            ;;
+        *)
+            # Assume that build.sh is never run on Windows.
+            cdylib_name=libjieba_vim_rs.so
+            dest_name=jieba_vim_rs.so
+            ;;
+    esac
+    # rm: used to delete $dest_name in case it's a symlink
+    cd rust_backend \
+        && cargo build -r --color=$color_when \
+        && rm -f ../pythonx/jieba_vim/$dest_name \
+        && cp target/release/$cdylib_name ../pythonx/jieba_vim/$dest_name
 }
 
 if has git uname curl; then


### PR DESCRIPTION
This PR aims to copy cdylib to pythonx directory in shell build scripts `build.sh` / `build.ps1`.

Before, we rely on a rust build script `expose-shared-library`, but it requires administrator permission on Windows, which is not desirable.
