### PR TITLE
Update build.sh shebang to be compatible with NixOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 has() {
     while [ -n "$1" ]; do


### PR DESCRIPTION
use `/usr/bin/env bash` to be compatible with nixos

-- authored by @TonyWu20