### PR TITLE
Release: v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 [vim-plug][vim-plug] (Vim / Neovim):
 
 ```vim
-Plug 'kkew3/jieba.vim', { 'tag': 'v2.0.0', 'do': { -> jieba_vim#install() } }
+Plug 'kkew3/jieba.vim', { 'tag': 'v2.1.0', 'do': { -> jieba_vim#install() } }
 ```
 
 [lazy.nvim][lazy-nvim] (Neovim):
@@ -33,7 +33,7 @@ Plug 'kkew3/jieba.vim', { 'tag': 'v2.0.0', 'do': { -> jieba_vim#install() } }
 ```lua
 {
     "kkew3/jieba.vim",
-    tag = "v2.0.0",
+    tag = "v2.1.0",
     build = ":call jieba_vim#install()",
     init = function()
       vim.g.jieba_vim_lazy = 1
@@ -134,7 +134,7 @@ Apache license v2；部分文件参照 [vim-LICENSE.txt](./vim-LICENSE.txt).
 [vim-plug][vim-plug] (Vim / Neovim):
 
 ```vim
-Plug 'kkew3/jieba.vim', { 'tag': 'v2.0.0', 'do': { -> jieba_vim#install() } }
+Plug 'kkew3/jieba.vim', { 'tag': 'v2.1.0', 'do': { -> jieba_vim#install() } }
 ```
 
 [lazy.nvim][lazy-nvim] (Neovim):
@@ -142,7 +142,7 @@ Plug 'kkew3/jieba.vim', { 'tag': 'v2.0.0', 'do': { -> jieba_vim#install() } }
 ```lua
 {
     "kkew3/jieba.vim",
-    tag = "v2.0.0",
+    tag = "v2.1.0",
     build = ":call jieba_vim#install()",
     init = function()
       vim.g.jieba_vim_lazy = 1


### PR DESCRIPTION
Features:

- Add support to word text objects (#32, #85).
- Don't need to restart vim after calling `jieba_vim#install()` for it to take effect (#87, #93).

Bug fixes:

- Count not working under `xmap` and `omap` (#86, #90).
- Spurious message during installation (#91, #92)

Documentation:

- Update README and Roadmap (11d11b61f0d04b14461b55a1917a4e31c0b4651f).