### PR TITLE
Simplify expression notation in `jieba_test_case` format

### DIFF
--- a/test/cases/basic_integrated_verification/main.jieba_test_case.j2
+++ b/test/cases/basic_integrated_verification/main.jieba_test_case.j2
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-#V 4
+#V 5
 
 ? !has:nvim
 
@@ -143,3 +143,5 @@ S1 visualmode()= '[= ']=
     {%- endfor %}
   {%- endfor %}
 {%- endfor %}
+
+// vim: ft=jieba_test_case

--- a/test/cases/d-special_nvim.jieba_test_case
+++ b/test/cases/d-special_nvim.jieba_test_case
@@ -17,7 +17,7 @@
 //
 // Best viewed in Vim.
 
-#V 4
+#V 5
 ? has:nvim
 
 #X i
@@ -25,6 +25,6 @@
 B0 |␊···abcd␊······␊
 K "ad2w
 B1 |······␊
-S1 "a=\<Newline>\<Space>\<Space>\<Space>abcd\<Newline>
+S1 "a=␊···abcd␊
 
 // vim: foldmethod=marker foldmarker=<<<,>>> foldlevel=0

--- a/test/cases/hanzi_sanity.jieba_test_case
+++ b/test/cases/hanzi_sanity.jieba_test_case
@@ -16,7 +16,7 @@
 //
 // Best viewed in Vim.
 
-#V 4
+#V 5
 #X i
 
 B0 |你@@好@@贝@@叶@@斯@@␊

--- a/test/cases/issue_16_isk.jieba_test_case
+++ b/test/cases/issue_16_isk.jieba_test_case
@@ -17,7 +17,7 @@
 //
 // Best viewed in Vim.
 
-#V 4
+#V 5
 
 #X i
 #B0 |aa.bb·ccc␊
@@ -30,6 +30,6 @@ K e
 B1 aa|.bb·ccc␊
 
 K e
-K :set\<Space>isk=a-z,.\<CR>
+K :set·isk=a-z,.␊
 K e
 B1 aa.b|b·ccc␊

--- a/test/cases/issue_6/main.jieba_test_case
+++ b/test/cases/issue_6/main.jieba_test_case
@@ -16,6 +16,8 @@
 //
 // Best viewed in Vim.
 
+#V 5
+
 ## Case 1 from https://github.com/kkew3/jieba.vim/issues/6.
 #X i
 #B0 a␊···␊b␊|···␊cd␊

--- a/test/cases/motion_failure.jieba_test_case
+++ b/test/cases/motion_failure.jieba_test_case
@@ -14,7 +14,7 @@
 
 // Best viewed in Vim.
 
-#V 4
+#V 5
 #X i
 
 ! See https://github.com/kkew3/jieba.vim/issues/64.

--- a/test/cases/omap_eol.jieba_test_case
+++ b/test/cases/omap_eol.jieba_test_case
@@ -16,7 +16,7 @@
 //
 // Best viewed in Vim.
 
-#V 4
+#V 5
 
 ## Single line, operating till eof.
 

--- a/test/cases/operator-resulting-pos.jieba_test_case
+++ b/test/cases/operator-resulting-pos.jieba_test_case
@@ -15,7 +15,7 @@
 // This file contains test cases that check for re-positioning the cursor after
 // d-special when 'startofline' option is unset.
 
-#V 4
+#V 5
 
 #X i
 

--- a/test/cases/xmap_back_empty_line.jieba_test_case.j2
+++ b/test/cases/xmap_back_empty_line.jieba_test_case.j2
@@ -17,7 +17,7 @@
 //
 // Best viewed in Vim.
 
-#V 4
+#V 5
 
 ## Case 1
 #X i

--- a/test/cases/xmap_ge_eol.jieba_test_case
+++ b/test/cases/xmap_ge_eol.jieba_test_case
@@ -18,7 +18,7 @@
 //
 // Best viewed in Vim.
 
-#V 4
+#V 5
 #X i
 
 #B0 ab|c␊

--- a/test/jieba_test_metatest/src/jieba_test_metatest/integrated_test.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/integrated_test.py
@@ -343,6 +343,9 @@ endfunction
         # Execute commands.
         outfile.write('" execute commands\n')
         for any_key_expr in self.any_key:
+            any_key_expr = any_key_expr.replace("·", "\\<Space>").replace(
+                "␊", "\\<CR>"
+            )
             outfile.write(
                 "call feedkeys({}, 't')\n".format(
                     vim.lit(f"{any_key_expr}\\<Esc>")

--- a/test/jieba_test_metatest/src/jieba_test_metatest/parser.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/parser.py
@@ -324,6 +324,11 @@ class StateExpr:
         be set to None.
         """
         name, _, value = arg.partition("=")
+        value = (
+            value.replace("␊", "\\<Newline>")
+            .replace("·", "\\<Space>")
+            .replace("┤", "\\<Tab>")
+        )
         if parse_as_incomplete:
             value = None
         if name.endswith("()"):

--- a/test/jieba_test_metatest/src/jieba_test_metatest/test_basic_integrated_verification.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/test_basic_integrated_verification.py
@@ -22,7 +22,7 @@ def test_from_raw_block_opt():
     raw_test_cases = parser.RawTestCases()
     span = parser.SourceSpan.for_file("foo")
     lines = """\
-#V 4
+#V 5
 
 #X bi
 #E CursorMoved=
@@ -209,7 +209,7 @@ S1 visualmode()= '[= ']=
 
 def test_write_std_run_custom_run():
     lines = """\
-#V 4
+#V 5
 ? !has:nvim
 
 #X bi

--- a/test/jieba_test_metatest/src/jieba_test_metatest/test_parser.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/test_parser.py
@@ -75,7 +75,7 @@ def test_raw_test_cases_extend_from_lines():
     raw_test_cases = m.RawTestCases()
     span = m.SourceSpan.for_file("foo")
     lines = """
-#V 4
+#V 5
 ##
 
 ? !has:nvim

--- a/test/jieba_test_metatest/src/jieba_test_metatest/version.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/version.py
@@ -12,4 +12,4 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-VERSION = "4"
+VERSION = "5"


### PR DESCRIPTION
This pull request aims to simplify test case authoring by introducing shorthand notations for several Vim escape strings.

In any-key-expression (`K` in integrated tests), the shorthand notations are:

- `·` for `\<Space>`
- `␊` for `\<CR>`

In state-expression (`S0`, `S1`), the shorthand notations are:

- `·` for `\<Space>`
- `␊` for `\<Newline>`
- `┤` for `\<Tab>`

Finally, existing test cases are updated accordingly.