### PR TITLE
Fix vim-repeat behavior after motion failure or yanks

### DIFF
--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -274,19 +274,12 @@ function! s:IsForwardMotion(motion)
     return a:motion ==? "w" || a:motion ==? "e" || a:motion ==? "iw" || a:motion ==? "aw"
 endfunction
 
-function! JiebaOmap(motion, repeat, count, operator, register, model_funcname)
-    noautocmd execute "normal! \<Esc>"
-    let l:orig_curpos = getcurpos()
+function s:JiebaModelOmapProcessed(model_funcname, motion, curpos, count, operator)
     if a:model_funcname !=# ""
-        let l:result_dict = function(a:model_funcname)(a:motion, l:orig_curpos, a:count, a:operator)
+        let l:result_dict = function(a:model_funcname)(a:motion, a:curpos, a:count, a:operator)
     else
-        let l:result_dict = JiebaModelOmap(a:motion, l:orig_curpos, a:count, a:operator)
+        let l:result_dict = JiebaModelOmap(a:motion, a:curpos, a:count, a:operator)
     endif
-    call cursor(l:result_dict["langle"][1:2])
-    " This no-op line effectively sets an undoable checkpoint such that |u|
-    " undos all operations up to this line.
-    call setline(".", getline("."))
-
     " Check if we are selecting an empty region.
     if l:result_dict["langle"] ==# l:result_dict["rangle"]
         \ && l:result_dict["selection"] ==# "exclusive"
@@ -295,11 +288,28 @@ function! JiebaOmap(motion, repeat, count, operator, register, model_funcname)
         \ && stridx(&cpoptions, "E") >= 0
         let l:result_dict["prevent_change"] = 1
     endif
+    return l:result_dict
+endfunction
+
+function! JiebaOmap(motion, repeat, count, operator, register, model_funcname)
+    let l:orig_curpos = getcurpos()
+    if type(a:model_funcname) == v:t_string
+        let l:result_dict = s:JiebaModelOmapProcessed(a:model_funcname, a:motion, l:orig_curpos, a:count, a:operator)
+    else
+        let l:result_dict = a:model_funcname
+    endif
+    call cursor(l:result_dict["langle"][1:2])
 
     if l:result_dict["prevent_change"]
         " Land the cursor to potentially a new position.
         call cursor(l:result_dict["cursor"][1:2])
     else
+        if a:operator !=# "y"
+            " This no-op line effectively sets an undoable checkpoint such that
+            " |u| undos all operations up to this line.
+            call setline(".", getline("."))
+        endif
+
         " Save original states.
         let l:orig_mark_a = getpos("'a")
         let l:orig_startofline = &startofline
@@ -405,19 +415,29 @@ for ky in s:motions + s:objects
 endfor
 
 function! s:JiebaOmap_internal_ky(ky, count, operator, register)
-    silent! call repeat#setreg("\<Plug>(Jieba_internal_o_" . a:ky . ")", a:register)
-    call JiebaOmap(a:ky, 1, a:count, a:operator, a:register, "")
-    silent! call repeat#set("\<Plug>(Jieba_internal_o_" . a:ky . ")", a:count)
+    let l:result_dict = s:JiebaModelOmapProcessed("", a:ky, getcurpos(), a:count, a:operator)
+    if !l:result_dict["prevent_change"] && a:operator !=# "y"
+        silent! call repeat#setreg(a:operator . "\<Plug>(Jieba_internal_o_" . a:ky . ")", a:register)
+    endif
+    call JiebaOmap(a:ky, 1, a:count, a:operator, a:register, l:result_dict)
+    if !l:result_dict["prevent_change"] && a:operator !=# "y"
+        silent! call repeat#set(a:operator . "\<Plug>(Jieba_internal_o_" . a:ky . ")", a:count)
+    endif
 endfunction
 
 function! s:JiebaOmap_ky(ky, count, operator, register)
-    silent! call repeat#setreg("\<Plug>(Jieba_internal_o_" . a:ky . ")", a:register)
-    call JiebaOmap(a:ky, 0, a:count, a:operator, a:register, "")
-    silent! call repeat#set("\<Plug>(Jieba_internal_o_" . a:ky . ")", a:count)
+    let l:result_dict = s:JiebaModelOmapProcessed("", a:ky, getcurpos(), a:count, a:operator)
+    if !l:result_dict["prevent_change"] && a:operator !=# "y"
+        silent! call repeat#setreg(a:operator . "\<Plug>(Jieba_internal_o_" . a:ky . ")", a:register)
+    endif
+    call JiebaOmap(a:ky, 0, a:count, a:operator, a:register, l:result_dict)
+    if !l:result_dict["prevent_change"] && a:operator !=# "y"
+        silent! call repeat#set(a:operator . "\<Plug>(Jieba_internal_o_" . a:ky . ")", a:count)
+    endif
 endfunction
 
 for ky in s:motions + s:objects
-    execute "nnoremap <expr> <silent> <Plug>(Jieba_internal_o_" . ky . ") " . '":<C-u>call <SID>JiebaOmap_internal_ky(' . "'" . ky . "'" . ', " . v:count1 . ", ' . "'" . '" . v:operator . "' . "'" . ', ' . "'" . '" . v:register . "' . "'" . ')<CR>"'
+    execute "onoremap <expr> <silent> <Plug>(Jieba_internal_o_" . ky . ") " . '"<Esc>:<C-u>call <SID>JiebaOmap_internal_ky(' . "'" . ky . "'" . ', " . v:count1 . ", ' . "'" . '" . v:operator . "' . "'" . ', ' . "'" . '" . v:register . "' . "'" . ')<CR>"'
     execute "onoremap <expr> <silent> <Plug>(Jieba_" . ky . ") " . '"<Esc>:<C-u>call <SID>JiebaOmap_ky(' . "'" . ky . "'" . ', " . v:count1 . ", ' . "'" . '" . v:operator . "' . "'" . ', ' . "'" . '" . v:register . "' . "'" . ')<CR>"'
 endfor
 

--- a/test/cases/issue_105/main.jieba_test_case
+++ b/test/cases/issue_105/main.jieba_test_case
@@ -97,18 +97,22 @@ S1 "a=ijk
 #X i
 #B0 ␊abc␊def␊ghi␊jkl␊m|no␊
 
+S0 startofline=1
 K "add
 B1 ␊abc␊def␊ghi␊|jkl␊
 S1 "a=mno␊
 
+S0 startofline=1
 K "add "b1000dge
 B1 |␊abc␊def␊ghi␊jkl␊
 S1 "a=mno␊ "b=
 
+S0 startofline=1
 K "add "b1000dge 3gg
 B1 ␊abc␊|def␊ghi␊jkl␊
 S1 "a=mno␊ "b=
 
+S0 startofline=1
 K "add "b1000dge 3gg .
 B1 ␊abc␊|ghi␊jkl␊
 S1 "a=def␊ "b=

--- a/test/cases/issue_105/main.jieba_test_case
+++ b/test/cases/issue_105/main.jieba_test_case
@@ -1,0 +1,266 @@
+// Copyright 2026 Kaiwen Wu. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy
+// of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// This file contains test cases that check for vim-repeat |.| behavior after
+// an operation that does not change the buffer.
+//
+// Best viewed in Vim.
+
+#V 5
+
+// This section checks for |.| after yank, an omap that notably does not change
+// the buffer.
+### Repeat after Yank ###
+
+// Case 1: repeat after |yy|.
+## dw -> yy -> .
+#X i
+#! dev
+#B0 abc·defg·h|ijk␊
+
+K "adw
+B1 abc·defg·|h␊
+S1 "a=ijk
+
+K "adw "byy
+B1 abc·defg·|h␊
+S1 "a=ijk "b=abc·defg·h␊
+
+K "adw "byy 0
+B1 |abc·defg·h␊
+S1 "a=ijk "b=abc·defg·h␊
+
+K "adw "byy 0 .
+B1 |defg·h␊
+S1 "a=abc· "b=abc·defg·h␊
+
+// Case 2: repeat after |yw|, a jieba omap.
+## dw -> yw -> .
+#X i
+#! dev
+#B0 abc·defg·h|ijk␊
+
+K "adw
+B1 abc·defg·|h␊
+S1 "a=ijk
+
+K "adw Fd
+B1 abc·|defg·h␊
+S1 "a=ijk
+
+K "adw Fd "byw
+B1 abc·|defg·h␊
+S1 "a=ijk "b=defg·
+
+K "adw Fd "byw 0
+B1 |abc·defg·h␊
+S1 "a=ijk "b=defg·
+
+K "adw Fd "byw 0 .
+B1 |defg·h␊
+S1 "a=abc· "b=defg·
+
+// Case 3: repeat after |yw|, but without a preceding buffer-changing
+// operation. Should do nothing.
+## yw -> .
+#X i
+#! dev
+#B0 abc·defg·h|ijk␊
+
+K "ayw
+B1 abc·defg·h|ijk␊
+S1 "a=ijk
+
+K "ayw 0
+B1 |abc·defg·hijk␊
+S1 "a=ijk
+
+K "ayw 0 .
+B1 |abc·defg·hijk␊
+S1 "a=ijk
+
+
+// This section checks for |.| after motion failure, which does not change
+// the buffer.
+### Repeat after Motion Failure ###
+
+// Case 1: repeat when the last valid operation is not a jieba omap.
+## dd -> failure -> .
+#X i
+#! dev
+#B0 ␊abc␊def␊ghi␊jkl␊m|no␊
+
+K "add
+B1 ␊abc␊def␊ghi␊|jkl␊
+S1 "a=mno␊
+
+K "add "b1000dge
+B1 |␊abc␊def␊ghi␊jkl␊
+S1 "a=mno␊ "b=
+
+K "add "b1000dge 3gg
+B1 ␊abc␊|def␊ghi␊jkl␊
+S1 "a=mno␊ "b=
+
+K "add "b1000dge 3gg .
+B1 ␊abc␊|ghi␊jkl␊
+S1 "a=def␊ "b=
+
+// Case 2: repeat when the last valid operation is a jieba omap.
+## dw -> failure -> .
+#X i
+#! dev
+#B0 ␊abcd|ef␊
+
+K "adw
+B1 ␊abc|d␊
+S1 "a=ef
+
+K "adw "b1000dge
+B1 |␊abcd␊
+S1 "a=ef "b=
+
+K "adw "b1000dge G100l
+B1 ␊abc|d␊
+S1 "a=ef "b=
+
+K "adw "b1000dge G100l .
+B1 ␊ab|c␊
+S1 "a=d "b=
+
+K "adw "b1000dge G100l .G0
+B1 ␊|abc␊
+S1 "a=d "b=
+
+// Case 3: repeat when there is no last valid operation.
+## failure -> .
+#X i
+#! dev
+#B0 ␊abc␊def␊ghi␊jkl␊m|no␊
+
+K "a1000dge
+B1 |␊abc␊def␊ghi␊jkl␊mno␊
+S1 "a=
+
+K "a1000dge 3gg
+B1 ␊abc␊|def␊ghi␊jkl␊mno␊
+S1 "a=
+
+K "a1000dge 3gg .
+B1 ␊abc␊|def␊ghi␊jkl␊mno␊
+S1 "a=
+
+
+// This section checks for |.| after a combo of yank and motion failure.
+### Combination of above ###
+
+// Case 1:
+## dw -> yw -> failure -> .
+#X i
+#! dev
+#B0 ␊abcd|ef␊
+
+K "adw
+B1 ␊abc|d␊
+S1 "a=ef
+
+K "adw "byw
+B1 ␊abc|d␊
+S1 "a=ef "b=d
+
+K "adw "byw "c1000dge
+B1 |␊abcd␊
+S1 "a=ef "b=d "c=
+
+K "adw "byw "c1000dge G0l
+B1 ␊a|bcd␊
+S1 "a=ef "b=d "c=
+
+K "adw "byw "c1000dge G0l .
+B1 ␊|a␊
+S1 "a=bcd "b=d "c=
+
+// Case 2:
+## dw -> failure -> yw -> .
+#X i
+#! dev
+#B0 ␊abcd|ef␊
+
+K "adw
+B1 ␊abc|d␊
+S1 "a=ef
+
+K "adw "b1000dge
+B1 |␊abcd␊
+S1 "a=ef "b=
+
+K "adw "b1000dge 2gg0l
+B1 ␊a|bcd␊
+S1 "a=ef "b=
+
+K "adw "b1000dge 2gg0l "cyw
+B1 ␊a|bcd␊
+S1 "a=ef "b= "c=bcd
+
+K "adw "b1000dge 2gg0l "cyw .
+B1 ␊|a␊
+S1 "a=bcd "b= "c=bcd
+
+// Case 3:
+## yy -> failure -> .
+#X i
+#! dev
+#B0 ␊abcdef␊·|ghi␊
+
+K "ayy
+B1 ␊abcdef␊·|ghi␊
+S1 "a=·ghi␊
+
+K "ayy "b1000dge
+B1 |␊abcdef␊·ghi␊
+S1 "a=·ghi␊ "b=
+
+K "ayy "b1000dge 2gg0l
+B1 ␊a|bcdef␊·ghi␊
+S1 "a=·ghi␊ "b=
+
+K "ayy "b1000dge 2gg0l .
+B1 ␊a|bcdef␊·ghi␊
+S1 "a=·ghi␊ "b=
+
+// Case 4:
+## failure -> yy -> .
+#X i
+#! dev
+#B0 ␊abcdef␊·|ghi␊
+
+K "a1000dge
+B1 |␊abcdef␊·ghi␊
+S1 "a=
+
+K "a1000dge 3gg0
+B1 ␊abcdef␊|·ghi␊
+S1 "a=
+
+K "a1000dge 3gg0 "byy
+B1 ␊abcdef␊|·ghi␊
+S1 "a= "b=·ghi␊
+
+K "a1000dge 3gg0 "byy 2gg0fb
+B1 ␊a|bcdef␊·ghi␊
+S1 "a= "b=·ghi␊
+
+K "a1000dge 3gg0 "byy 2gg0fb .
+B1 ␊a|bcdef␊·ghi␊
+S1 "a= "b=·ghi␊

--- a/test/cases/issue_105/main.jieba_test_case
+++ b/test/cases/issue_105/main.jieba_test_case
@@ -26,7 +26,6 @@
 // Case 1: repeat after |yy|.
 ## dw -> yy -> .
 #X i
-#! dev
 #B0 abc·defg·h|ijk␊
 
 K "adw
@@ -48,7 +47,6 @@ S1 "a=abc· "b=abc·defg·h␊
 // Case 2: repeat after |yw|, a jieba omap.
 ## dw -> yw -> .
 #X i
-#! dev
 #B0 abc·defg·h|ijk␊
 
 K "adw
@@ -75,7 +73,6 @@ S1 "a=abc· "b=defg·
 // operation. Should do nothing.
 ## yw -> .
 #X i
-#! dev
 #B0 abc·defg·h|ijk␊
 
 K "ayw
@@ -98,7 +95,6 @@ S1 "a=ijk
 // Case 1: repeat when the last valid operation is not a jieba omap.
 ## dd -> failure -> .
 #X i
-#! dev
 #B0 ␊abc␊def␊ghi␊jkl␊m|no␊
 
 K "add
@@ -120,7 +116,6 @@ S1 "a=def␊ "b=
 // Case 2: repeat when the last valid operation is a jieba omap.
 ## dw -> failure -> .
 #X i
-#! dev
 #B0 ␊abcd|ef␊
 
 K "adw
@@ -146,7 +141,6 @@ S1 "a=d "b=
 // Case 3: repeat when there is no last valid operation.
 ## failure -> .
 #X i
-#! dev
 #B0 ␊abc␊def␊ghi␊jkl␊m|no␊
 
 K "a1000dge
@@ -168,7 +162,6 @@ S1 "a=
 // Case 1:
 ## dw -> yw -> failure -> .
 #X i
-#! dev
 #B0 ␊abcd|ef␊
 
 K "adw
@@ -194,7 +187,6 @@ S1 "a=bcd "b=d "c=
 // Case 2:
 ## dw -> failure -> yw -> .
 #X i
-#! dev
 #B0 ␊abcd|ef␊
 
 K "adw
@@ -220,7 +212,6 @@ S1 "a=bcd "b= "c=bcd
 // Case 3:
 ## yy -> failure -> .
 #X i
-#! dev
 #B0 ␊abcdef␊·|ghi␊
 
 K "ayy
@@ -242,7 +233,6 @@ S1 "a=·ghi␊ "b=
 // Case 4:
 ## failure -> yy -> .
 #X i
-#! dev
 #B0 ␊abcdef␊·|ghi␊
 
 K "a1000dge

--- a/test/cases/issue_105/vimrc
+++ b/test/cases/issue_105/vimrc
@@ -1,0 +1,22 @@
+" Copyright 2026 Kaiwen Wu. All Rights Reserved.
+"
+" Licensed under the Apache License, Version 2.0 (the "License"); you may not
+" use this file except in compliance with the License. You may obtain a copy
+" of the License at
+"
+"     http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+" WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+" License for the specific language governing permissions and limitations
+" under the License.
+
+execute "source " . expand("<sfile>:p:h:h") . "/vimrc"
+
+if !exists("$VIM_REPEAT_DIR")
+    echoerr '$VIM_REPEAT_DIR not set'
+    cquit 9
+    finish
+endif
+let &rtp .= "," . $VIM_REPEAT_DIR


### PR DESCRIPTION
The dot mapping [`.`](https://vimhelp.org/repeat.txt.html#.) implemented through [`vim-repeat`](https://github.com/tpope/vim-repeat) should repeat last change. However, currently it *always* repeats last operation, even if it's a yank or a motion failure that does not modify the buffer. This pull request aims to fix it.

Check commit e60fe5cc9149339dcb39f4b097ceeac0cbec4325 for the test cases.

Will close #105.