### PR TITLE
Fix xmap ge error at eol

### DIFF
--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -249,6 +249,7 @@ function! JiebaXmap(motion, count, model_funcname)
     let l:orig_mark_a = getpos("'a")
     let l:orig_mark_b = getpos("'b")
     normal! gvomaomb
+    noautocmd silent execute "normal! \<Esc>"
     let l:visual_begin = getpos("'a")
     let l:visial_end = getpos("'b")
     call setpos("'a", l:orig_mark_a)


### PR DESCRIPTION
This error happened only when more than one chars have been selected. That's why it was not captured by [xmap_ge_eol](https://github.com/kkew3/jieba.vim/blob/rust/test/cases/xmap_ge_eol.jieba_test_case).

It turns out that it's really simple to fix the error. However, I find it difficult to design a test case that prove the fix. Since the fixing logic appears pretty trivial, we will accept the absence of the test case here.

Will close #108.