### PR TITLE
Use `<Cmd>` mapping as an attempt to fully resolve issue #83

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,8 +283,6 @@ jobs:
       +${{ matrix.vim.glue-lang }}
       on ${{ matrix.vim.os }}
     runs-on: ${{ matrix.vim.os }}
-    needs:
-      - build-jieba-vim-cdylib
     strategy:
       fail-fast: false
       matrix:
@@ -346,6 +344,9 @@ jobs:
       GLUE_LANG: ${{ matrix.vim.glue-lang }}
       JIEBA_VIM_DIR: ${{ github.workspace }}
       VIM_REPEAT_DIR: ${{ github.workspace }}/.vim_bundle/vim-repeat
+      # jieba.vim build variables
+      JIEBA_VIM_BUILD_FROM_SORUCE: '1'
+      JIEBA_VIM_INSTALL_NVIM: ${{ matrix.vim.distr == 'nvim' && '1' || '' }}
     steps:
       # Prepare env.
       - uses: actions/checkout@v6
@@ -362,18 +363,18 @@ jobs:
       - name: Run uv-sync
         shell: bash
         run: uv sync
-      - name: Get jieba.vim cdylib for vim(+python3)
-        if: matrix.vim.distr == 'vim'
-        uses: actions/download-artifact@v7
-        with:
-          name: jieba-vim-cdylib-python
-          path: pythonx/jieba_vim
-      - name: Get jieba.vim cdylib for nvim
-        if: matrix.vim.distr == 'nvim'
-        uses: actions/download-artifact@v7
-        with:
-          name: jieba-vim-cdylib-lua
-          path: lua/jieba_vim
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build jieba.vim cdylib
+        shell: bash
+        run: |
+          case ${{ matrix.vim.os }} in
+            windows-*)
+              powershell -ExecutionPolicy Bypass -file ./build.ps1
+              ;;
+            *)
+              ./build.sh
+              ;;
+          esac
       - name: Get a filename-safe version of vim.version
         id: safe-version
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,8 @@ jobs:
       Integrated test for
       ${{ matrix.vim.distr }}@${{ matrix.vim.version }}
       +${{ matrix.vim.glue-lang }}
-    runs-on: ubuntu-24.04
+      on ${{ matrix.vim.os }}
+    runs-on: ${{ matrix.vim.os }}
     needs:
       - build-jieba-vim-cdylib
     strategy:
@@ -291,15 +292,51 @@ jobs:
           - distr: vim
             version: v8.2.3455
             glue-lang: py39
+            os: ubuntu-24.04
           - distr: vim
             version: v9.1.0000
             glue-lang: py311
+            os: ubuntu-24.04
+          - distr: vim
+            version: v9.2.0321
+            glue-lang: py311
+            os: ubuntu-24.04
           - distr: nvim
             version: v0.10.2
             glue-lang: lua51
+            os: ubuntu-24.04
+          - distr: nvim
+            version: v0.10.2
+            glue-lang: lua51
+            os: windows-latest
+          - distr: nvim
+            version: v0.10.2
+            glue-lang: lua51
+            os: macos-14
           - distr: nvim
             version: v0.11.5
             glue-lang: lua51
+            os: ubuntu-24.04
+          - distr: nvim
+            version: v0.11.5
+            glue-lang: lua51
+            os: windows-latest
+          - distr: nvim
+            version: v0.11.5
+            glue-lang: lua51
+            os: macos-14
+          - distr: nvim
+            version: v0.12.2
+            glue-lang: lua51
+            os: ubuntu-24.04
+          - distr: nvim
+            version: v0.12.2
+            glue-lang: lua51
+            os: windows-latest
+          - distr: nvim
+            version: v0.12.2
+            glue-lang: lua51
+            os: macos-14
     env:
       # uv variables
       UV_PROJECT: ${{ github.workspace }}/test/jieba_test_metatest
@@ -343,10 +380,23 @@ jobs:
         run: |
           SAFE_VERSION="$(echo "${{ matrix.vim.version }}" | tr . _)"
           echo "safe_version=${SAFE_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "vim_dist_name=${{ matrix.vim.distr }}_${SAFE_VERSION}_${{ matrix.vim.glue-lang }}" >> "$GITHUB_OUTPUT"
+          echo "vim_dist_name=${{ matrix.vim.distr }}_${SAFE_VERSION}_${{ matrix.vim.glue-lang }}_${{ matrix.vim.os }}" >> "$GITHUB_OUTPUT"
       - name: Expand templates
         shell: bash
-        run: make -C test/cases clean all
+        run: |
+          case ${{ matrix.vim.os }} in
+            windows-*)
+              choco install make
+              ;;
+            macos-*)
+              brew install make
+              ;;
+          esac
+          make -C test/cases clean all
+        env:
+          # This should fix UnicodeEncodeError on Windows.
+          PYTHONUTF8: '1'
+          PYTHONIOENCODING: utf-8
       - name: Setup vim plugins
         shell: bash
         run: |
@@ -410,18 +460,18 @@ jobs:
           TOFILE=i-success-${{ steps.safe-version.outputs.vim_dist_name }}.txt
           echo "tofile=$TOFILE" >> "$GITHUB_OUTPUT"
           cat <<'EOF' > "$TOFILE"
-          ${{ steps.run-i-test.outputs.exit_code }} ${{ matrix.vim.distr }} @${{ matrix.vim.version }} +${{ matrix.vim.glue-lang }}
+          ${{ steps.run-i-test.outputs.exit_code }} ${{ matrix.vim.distr }} @${{ matrix.vim.version }} +${{ matrix.vim.glue-lang }} on ${{ matrix.vim.os }}
           EOF
       - uses: actions/upload-artifact@v6
         with:
-          name: i-success-${{ matrix.vim.distr }}-${{ matrix.vim.version }}-${{ matrix.vim.glue-lang }}
+          name: i-success-${{ matrix.vim.distr }}-${{ matrix.vim.version }}-${{ matrix.vim.glue-lang }}-${{ matrix.vim.os }}
           path: ${{ steps.indicate-state.outputs.tofile }}
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
       - uses: actions/upload-artifact@v6
         with:
-          name: i-report-${{ matrix.vim.distr }}-${{ matrix.vim.version }}-${{ matrix.vim.glue-lang }}
+          name: i-report-${{ matrix.vim.distr }}-${{ matrix.vim.version }}-${{ matrix.vim.glue-lang }}-${{ matrix.vim.os }}
           path: |
             i_test/warns_${{ steps.safe-version.outputs.vim_dist_name }}
             i_test/errs_${{ steps.safe-version.outputs.vim_dist_name }}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,7 +4,7 @@
 
 # 如何与 im-select.nvim 配套使用
 
-[`im-select.nvim`][im-select] 可以用于自动切换输入法。目前需要在 `set_default_events` 中禁用 `CmdlineLeave`（见 issue [#83][issue83] 中的讨论）。一个在 macOS 下可行的 [lazy.nvim][lazy] 配置示例如下：
+[`im-select.nvim`][im-select] 可以用于自动切换输入法。目前需要在 `set_default_events` 中禁用 `CmdlineLeave` 或设置 `async_switch_im = false`（见 issue [#83][issue83] 中的讨论）。一个在 macOS 下可行的 [lazy.nvim][lazy] 配置示例如下：
 
 ```lua
 {
@@ -13,12 +13,9 @@
         require('im_select').setup({
             default_command = { "/usr/local/bin/macism" },
             default_im_select  = "com.apple.keylayout.US",
-
-            -- 此处不能有 "CmdlineLeave"
-            set_default_events = { "InsertLeave" },
-
+            set_default_events = { "InsertLeave", "CmdlineLeave" },
             set_previous_events = { "InsertEnter" },
-            async_switch_im = true
+            async_switch_im = false
         })
     end,
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,10 @@
+# Vim 至少需要什么版本
+
+本插件在 Vim-8.2.3455、Vim-9.1.0000、Neovim-0.10.2、Neovim-0.11.5 上测试通过。所以至少需要 Vim-8.2.3455。
+
 # 如何与 im-select.nvim 配套使用
 
-[`im-select.nvim`][im-select] 可以用于自动切换输入法。目前需要在 `set_default_events` 中禁用 `CmdlineLeave`（见 issue #83 中的讨论）。一个在 macOS 下可行的 [lazy.nvim][lazy] 配置示例如下：
+[`im-select.nvim`][im-select] 可以用于自动切换输入法。目前需要在 `set_default_events` 中禁用 `CmdlineLeave`（见 issue [#83][issue83] 中的讨论）。一个在 macOS 下可行的 [lazy.nvim][lazy] 配置示例如下：
 
 ```lua
 {
@@ -23,3 +27,4 @@
 
 [im-select]: https://github.com/keaising/im-select.nvim
 [lazy]: https://lazy.folke.io/
+[issue83]: https://github.com/kkew3/jieba.vim/issues/83

--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -424,7 +424,7 @@ endfunction
 " Keep in one line to help debug. There is no readability anyway even if this
 " is properly wrapped to 80 width. Same below.
 for ky in s:motions
-    execute 'nnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') ":<C-u>call <SID>JiebaNmap_ky(' . "'" . ky . "', v:count1" . ')<CR>"'
+    execute 'nnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') "<Cmd>call <SID>JiebaNmap_ky(' . "'" . ky . "', v:count1" . ')<CR>"'
 endfor
 
 function! s:JiebaXmap_ky(ky, count)
@@ -432,7 +432,7 @@ function! s:JiebaXmap_ky(ky, count)
 endfunction
 
 for ky in s:motions + s:objects
-    execute 'xnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') ":<C-u>call <SID>JiebaXmap_ky(' . "'" . ky . "', v:count1" . ')<CR>"'
+    execute 'xnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') "<Cmd>call <SID>JiebaXmap_ky(' . "'" . ky . "', v:count1" . ')<CR>"'
 endfor
 
 function! s:JiebaOmap_internal_ky(ky, count, operator, register)
@@ -458,8 +458,8 @@ function! s:JiebaOmap_ky(ky, count, operator, register)
 endfunction
 
 for ky in s:motions + s:objects
-    execute "onoremap <expr> <silent> <Plug>(Jieba_internal_o_" . ky . ") " . '"<Esc>:<C-u>call <SID>JiebaOmap_internal_ky(' . "'" . ky . "'" . ', " . v:count1 . ", ' . "'" . '" . v:operator . "' . "'" . ', ' . "'" . '" . v:register . "' . "'" . ')<CR>"'
-    execute "onoremap <expr> <silent> <Plug>(Jieba_" . ky . ") " . '"<Esc>:<C-u>call <SID>JiebaOmap_ky(' . "'" . ky . "'" . ', " . v:count1 . ", ' . "'" . '" . v:operator . "' . "'" . ', ' . "'" . '" . v:register . "' . "'" . ')<CR>"'
+    execute "onoremap <expr> <silent> <Plug>(Jieba_internal_o_" . ky . ") " . '"<Esc><Cmd>call <SID>JiebaOmap_internal_ky(' . "'" . ky . "'" . ', " . v:count1 . ", ' . "'" . '" . v:operator . "' . "'" . ', ' . "'" . '" . v:register . "' . "'" . ')<CR>"'
+    execute "onoremap <expr> <silent> <Plug>(Jieba_" . ky . ") " . '"<Esc><Cmd>call <SID>JiebaOmap_ky(' . "'" . ky . "'" . ', " . v:count1 . ", ' . "'" . '" . v:operator . "' . "'" . ', ' . "'" . '" . v:register . "' . "'" . ')<CR>"'
 endfor
 
 let s:modes = ["n", "x", "o"]

--- a/test/cases/issue_83_im_select.jieba_test_case
+++ b/test/cases/issue_83_im_select.jieba_test_case
@@ -1,0 +1,33 @@
+// Copyright 2026 Kaiwen Wu. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy
+// of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// This file contains test cases for issue #83. See
+// https://github.com/kkew3/jieba.vim/issues/83 for details.
+
+#V 5
+
+#X i
+#B0 abc·|def·ghi␊
+
+K cwfoo
+E CmdlineLeave=0 InsertLeave=1 InsertEnter=1
+
+K dw
+E CmdlineLeave=0 InsertLeave=0 InsertEnter=0
+
+K vw
+E CmdlineLeave=0 InsertLeave=0 InsertEnter=0
+
+K w
+E CmdlineLeave=0 InsertLeave=0 InsertEnter=0


### PR DESCRIPTION
Note: current workaround for #83 is to disable CmdlineLeave event.

Caveat: `<Cmd>` mapping requires at least Vim-8.2.1978 (released in Nov 2020). We may need to either add a note in FAQ, or revert to `:<C-u>` mapping conditionally in case some user is using older Vim and files an issue for it. But for now, we will stick to `<Cmd>` mapping for simplicity.