### PR TITLE
Override linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/dev_scripts -linguist-detectable
 /test/jieba_test_metatest -linguist-detectable
 /test/jieba_test_case_syntax -linguist-detectable
 *.jieba_test_case linguist-language=jieba-test-case

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /test/jieba_test_metatest -linguist-detectable
 /test/jieba_test_case_syntax -linguist-detectable
+*.jieba_test_case linguist-language=jieba-test-case

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/test/jieba_test_metatest -linguist-detectable
+/test/jieba_test_case_syntax -linguist-detectable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,7 @@ jobs:
             --exclude-files 'jieba_vim_rs_binding_lua51/*' \
             --exclude-files 'jieba_vim_rs_binding_py3/*' \
             --packages jieba_vim_rs_core
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         with:
           files: rust_backend/cobertura.xml
           disable_search: true


### PR DESCRIPTION
This pull request aims primarily to ignore python test harness from linguist statistics, which would otherwise be misleading as if this repository were almost a python codebase.