### PR TITLE
Add back CI on push to `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - opened
       - synchronize
       - reopened
+  push:
+    branches:
+      - main
 
 jobs:
   build-jieba-vim-cdylib:


### PR DESCRIPTION
Can't figure out why it was removed in commit 0e4cd6a52f7c8d66bef29af42df6796812746e69, since its use has been made clear in commit 2a76f316dec8666533e597c8756939e7794d00ae:

> Add back checks on push to ensure the CI badge remains accurate.