### PR TITLE
Improvements on `jieba_vim#install()` function

### DIFF
--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -140,7 +140,7 @@ function s:JiebaPreviewCancel()
     execute "hi clear JiebaPreview"
 endfunction
 
-function s:JiebaModelPreview(...)
+function s:JiebaModelPreview(...) abort
     if !s:loaded_jieba_vim_cdylib 
         throw "cdylib unloaded; run jieba_vim#install() first"
     endif
@@ -187,7 +187,7 @@ for ky in s:motions
 endfor
 nnoremap <silent> <Plug>(Jieba_preview_cancel) :<C-u>call <SID>JiebaPreviewCancel()<CR>
 
-function! JiebaModelNmap(...)
+function! JiebaModelNmap(...) abort
     if !s:loaded_jieba_vim_cdylib
         throw "cdylib unloaded; run jieba_vim#install() first"
     endif
@@ -203,7 +203,7 @@ function! JiebaModelNmap(...)
     endif
 endfunction
 
-function! JiebaModelXmap(...)
+function! JiebaModelXmap(...) abort
     if !s:loaded_jieba_vim_cdylib
         throw "cdylib unloaded; run jieba_vim#install() first"
     endif
@@ -219,7 +219,7 @@ function! JiebaModelXmap(...)
     endif
 endfunction
 
-function! JiebaModelOmap(...)
+function! JiebaModelOmap(...) abort
     if !s:loaded_jieba_vim_cdylib
         throw "cdylib unloaded; run jieba_vim#install() first"
     endif

--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -496,14 +496,15 @@ augroup END
 function! jieba_vim#install()
     if s:is_win && !has("win32unix")
         let l:script = s:base_dir . "/build.ps1"
-        let l:script = "powershell -ExecutionPolicy Bypass -file " . shellescape(l:script)
+        let l:cmd = ["powershell", "-ExecutionPolicy", "Bypass", "-file", l:script]
     else
         let l:script = s:base_dir . "/build.sh"
+        let l:cmd = [l:script]
     endif
     if has("nvim")
         let $JIEBA_VIM_INSTALL_NVIM = "1"
     endif
-    let l:build_output = system(l:script)
+    let l:build_output = system(l:cmd)
     if v:shell_error
         throw "jieba_vim#install: build script " . l:script
             \ . " returns " . v:shell_error

--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -88,13 +88,13 @@ function! s:InitWordMotion() abort
     if has("nvim")
         let l:init_word_motion_err = luaeval("jieba_vim:init_word_motion(unpack(_A))", l:args)
         if l:init_word_motion_err !=# ""
-            echoerr l:init_word_motion_err
+            throw l:init_word_motion_err
         endif
     else
         let l:init_word_motion_err = py3eval(
             \ "jieba_vim.navigation.init_word_motion(*vim.eval('l:args'))")
         if l:init_word_motion_err !=# "" && l:init_word_motion_err !=# v:none
-            echoerr l:init_word_motion_err
+            throw l:init_word_motion_err
         endif
     endif
     let s:loaded_jieba_vim_word_motion = 1

--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -503,9 +503,11 @@ function! jieba_vim#install()
     if has("nvim")
         let $JIEBA_VIM_INSTALL_NVIM = "1"
     endif
-    call system(l:script)
+    let l:build_output = system(l:script)
     if v:shell_error
-        throw "Failed to run build script: " . l:script
+        throw "jieba_vim#install: build script " . l:script
+            \ . " returns " . v:shell_error
+            \ . " with message: " . l:build_output
     endif
     call s:CheckCdylib()
     let s:loaded_jieba_vim_word_motion = 0


### PR DESCRIPTION
- Bypass shell invocation when launching the build script. Instead, run `powershell` or `bash` directly as a subprocess. This may either eliminate certain shebang issues, or let the build script panic loudly (e.g. #119).
- Improve error message in case build failed, by including the stdout and stderr of the build script.