### PR TITLE
Fix spurious error message when cdylib is not loaded successfully

### DIFF
--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -61,7 +61,7 @@ else
     let s:cdylib_suffix = ".so"
 endif
 
-function! s:CheckCdylib()
+function! s:CheckCdylib() abort
     if has("nvim")
         if filereadable(s:base_dir . "/lua/jieba_vim/jieba_vim_rs" . s:cdylib_suffix)
             lua jieba_vim = require("jieba_vim")
@@ -78,6 +78,8 @@ function! s:CheckCdylib()
         endif
     endif
 endfunction
+
+let s:loaded_jieba_vim_cdylib = 0
 call s:CheckCdylib()
 
 function! s:InitWordMotion() abort
@@ -507,6 +509,7 @@ function! jieba_vim#install()
     if v:shell_error
         throw "Failed to run build script: " . l:script
     endif
+    let s:loaded_jieba_vim_cdylib = 0
     call s:CheckCdylib()
     let s:loaded_jieba_vim_word_motion = 0
     call s:InitWordMotion()


### PR DESCRIPTION
This pull request aims to fix the spurious error message popped up when a cdylib file exists but cannot be loaded successfully. A screenshot of the error message is displayed below.

<img width="1158" height="147" alt="screenshot of the error message" src="https://github.com/user-attachments/assets/c4f8b84e-c13d-45e3-9a97-ad1f93757d30" />

The bugbear is the missing `abort` argument in auxiliary function `s:CheckCdylib()`, such that `s:loaded_jieba_vim_cdylib` indicator is set to 1 even if cdylib is not loaded successfully.