### PR TITLE
Expose build error via `g:jieba_vim_build_error`

### DIFF
--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -505,9 +505,13 @@ function! jieba_vim#install()
     if has("nvim")
         let $JIEBA_VIM_INSTALL_NVIM = "1"
     endif
-    call system(l:script)
+    let g:jieba_vim_build_error = system(l:script)
     if v:shell_error
-        throw "Failed to run build script: " . l:script
+        throw "jieba_vim#install: build script " . l:script
+            \ . " returns " . v:shell_error
+            \ . " (see g:jieba_vim_build_error)"
+    else
+        unlet g:jieba_vim_build_error
     endif
     let s:loaded_jieba_vim_cdylib = 0
     call s:CheckCdylib()


### PR DESCRIPTION
This pull request aims to expose `jieba_vim#install()` error outputs to users who are likely in need in case build failed.