### PR TITLE
Collect `<expr>`-mappings into functions

### DIFF
--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -419,49 +419,40 @@ function! JiebaOmap(motion, repeat, count, operator, register, model_funcname)
     endif
 endfunction
 
-function! s:JiebaNmap_ky(ky, count)
-    call JiebaNmap(a:ky, a:count, "")
+function! JiebaNmapExpr(motion, model_funcname)
+    return "\<Cmd>call JiebaNmap('" . a:motion . "', v:count1, '" . a:model_funcname . "')\<CR>"
 endfunction
 
-" Keep in one line to help debug. There is no readability anyway even if this
-" is properly wrapped to 80 width. Same below.
 for ky in s:motions
-    execute 'nnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') "<Cmd>call <SID>JiebaNmap_ky(' . "'" . ky . "', v:count1" . ')<CR>"'
+    execute 'nnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') JiebaNmapExpr("' . ky . '", "")'
 endfor
 
-function! s:JiebaXmap_ky(ky, count)
-    call JiebaXmap(a:ky, a:count, "")
+function! JiebaXmapExpr(motion, model_funcname)
+    return "\<Cmd>call JiebaXmap('" . a:motion . "', v:count1, '" . a:model_funcname . "')\<CR>"
 endfunction
 
 for ky in s:motions + s:objects
-    execute 'xnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') "<Cmd>call <SID>JiebaXmap_ky(' . "'" . ky . "', v:count1" . ')<CR>"'
+    execute 'xnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') JiebaXmapExpr("' . ky . '", "")'
 endfor
 
-function! s:JiebaOmap_internal_ky(ky, count, operator, register)
-    let l:result_dict = s:JiebaModelOmapProcessed("", a:ky, getcurpos(), a:count, a:operator)
+function! JiebaOmapRepeat(motion, repeat, count, operator, register, model_funcname)
+    let l:result_dict = s:JiebaModelOmapProcessed(a:model_funcname, a:motion, getcurpos(), a:count, a:operator)
     if !l:result_dict["prevent_change"] && a:operator !=# "y"
-        silent! call repeat#setreg(a:operator . "\<Plug>(Jieba_internal_o_" . a:ky . ")", a:register)
+        silent! call repeat#setreg(a:operator . "\<Plug>(Jieba_internal_o_" . a:motion . ")", a:register)
     endif
-    call JiebaOmap(a:ky, 1, a:count, a:operator, a:register, l:result_dict)
+    call JiebaOmap(a:motion, a:repeat, a:count, a:operator, a:register, l:result_dict)
     if !l:result_dict["prevent_change"] && a:operator !=# "y"
-        silent! call repeat#set(a:operator . "\<Plug>(Jieba_internal_o_" . a:ky . ")", a:count)
+        silent! call repeat#set(a:operator . "\<Plug>(Jieba_internal_o_" . a:motion . ")", a:count)
     endif
 endfunction
 
-function! s:JiebaOmap_ky(ky, count, operator, register)
-    let l:result_dict = s:JiebaModelOmapProcessed("", a:ky, getcurpos(), a:count, a:operator)
-    if !l:result_dict["prevent_change"] && a:operator !=# "y"
-        silent! call repeat#setreg(a:operator . "\<Plug>(Jieba_internal_o_" . a:ky . ")", a:register)
-    endif
-    call JiebaOmap(a:ky, 0, a:count, a:operator, a:register, l:result_dict)
-    if !l:result_dict["prevent_change"] && a:operator !=# "y"
-        silent! call repeat#set(a:operator . "\<Plug>(Jieba_internal_o_" . a:ky . ")", a:count)
-    endif
+function! JiebaOmapRepeatExpr(motion, repeat, model_funcname)
+    return "\<Esc>\<Cmd>call JiebaOmapRepeat('" . a:motion . "', " . a:repeat . ", " . v:count1 . ", '" . v:operator . "', '" . v:register . "', '" . a:model_funcname . "')\<CR>"
 endfunction
 
 for ky in s:motions + s:objects
-    execute "onoremap <expr> <silent> <Plug>(Jieba_internal_o_" . ky . ") " . '"<Esc><Cmd>call <SID>JiebaOmap_internal_ky(' . "'" . ky . "'" . ', " . v:count1 . ", ' . "'" . '" . v:operator . "' . "'" . ', ' . "'" . '" . v:register . "' . "'" . ')<CR>"'
-    execute "onoremap <expr> <silent> <Plug>(Jieba_" . ky . ") " . '"<Esc><Cmd>call <SID>JiebaOmap_ky(' . "'" . ky . "'" . ', " . v:count1 . ", ' . "'" . '" . v:operator . "' . "'" . ', ' . "'" . '" . v:register . "' . "'" . ')<CR>"'
+    execute 'onoremap <expr> <silent> <Plug>(Jieba_internal_o_' . ky . ') JiebaOmapRepeatExpr("' . ky . '", 1, "")'
+    execute 'onoremap <expr> <silent> <Plug>(Jieba_' . ky . ') JiebaOmapRepeatExpr("' . ky . '", 0, "")'
 endfor
 
 let s:modes = ["n", "x", "o"]

--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -264,8 +264,7 @@ function! JiebaXmap(motion, count, model_funcname)
     noautocmd execute "normal! \<Esc>"
     let l:orig_mark_a = getpos("'a")
     let l:orig_mark_b = getpos("'b")
-    normal! gvomaomb
-    noautocmd silent execute "normal! \<Esc>"
+    noautocmd silent execute "normal! gvomaomb\<Esc>"
     let l:visual_begin = getpos("'a")
     let l:visial_end = getpos("'b")
     call setpos("'a", l:orig_mark_a)

--- a/test/jieba_test_metatest/src/jieba_test_metatest/basic_integrated_verification.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/basic_integrated_verification.py
@@ -303,6 +303,22 @@ function! JiebaOracleModel(...)
 endfunction
 
 """)
+
+        # Define mapping.
+        expr_func = {
+            "n": "JiebaNmapExpr",
+            "x": "JiebaXmapExpr",
+            "o": "JiebaOmapExpr",
+        }[self.mode]
+        outfile.write(f"""\
+" define mapping
+function! JiebaOmapExpr(motion, model_funcname)
+    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
+endfunction
+{self.mode}noremap <expr> <silent> {self.motion_key} {expr_func}("{self.motion_key}", "JiebaOracleModel")
+
+""")
+
         # Write state_before setup.
         outfile.write('" state_before setup\n')
         for state_expr in self.initial_states:
@@ -517,29 +533,13 @@ silent execute "source " . expand("%:p:h") . "/Session.vim"
         # Cursor movement.
         outfile.write('" cursor movement\n')
         if self.mode == "n":
-            outfile.write(
-                'call JiebaNmap({motion_key}, {count}, "JiebaOracleModel")\n'.format(
-                    motion_key=vim.lit(self.motion_key), count=self.count or "0"
-                )
-            )
+            outfile.write(f"normal {self.count}{self.motion_key}\n")
         elif self.mode == "x":
-            outfile.write(
-                'call JiebaXmap({motion_key}, {count}, "JiebaOracleModel")\n'.format(
-                    motion_key=vim.lit(self.motion_key), count=self.count or "0"
-                )
-            )
+            outfile.write(f"normal gv{self.count}{self.motion_key}\n")
         else:
+            reg = f'"{self.register}' if self.register else ""
             outfile.write(
-                'call JiebaOmap({motion_key}, 0, {count}, {operator}, {register}, "JiebaOracleModel")\n'.format(
-                    motion_key=vim.lit(self.motion_key),
-                    count=self.count or "0",
-                    operator=vim.lit(self.operator),
-                    register=(
-                        vim.lit(self.register)
-                        if self.register
-                        else vim.lit('"')
-                    ),
-                )
+                f"normal {reg}{self.operator}{self.count}{self.motion_key}\n"
             )
         outfile.write('execute "normal! \\<Esc>"\n\n')
         outfile.write(

--- a/test/jieba_test_metatest/src/jieba_test_metatest/test_basic_integrated_verification.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/test_basic_integrated_verification.py
@@ -431,6 +431,12 @@ function! JiebaOracleModel(...)
     return g:model_output
 endfunction
 
+" define mapping
+function! JiebaOmapExpr(motion, model_funcname)
+    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
+endfunction
+nnoremap <expr> <silent> w JiebaNmapExpr("w", "JiebaOracleModel")
+
 " state_before setup
 let &selection = "exclusive"
 
@@ -521,6 +527,12 @@ function! JiebaOracleModel(...)
     return g:model_output
 endfunction
 
+" define mapping
+function! JiebaOmapExpr(motion, model_funcname)
+    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
+endfunction
+nnoremap <expr> <silent> w JiebaNmapExpr("w", "JiebaOracleModel")
+
 " state_before setup
 let &selection = "exclusive"
 
@@ -569,7 +581,7 @@ endif
 
 let g:jieba_test_case_events_count = {}
 " cursor movement
-call JiebaNmap("w", 0, "JiebaOracleModel")
+normal w
 execute "normal! \\<Esc>"
 
 let g:jieba_test_case_events_count_frozen = copy(g:jieba_test_case_events_count)
@@ -647,6 +659,12 @@ function! JiebaOracleModel(...)
     let g:model_output = call(function("JiebaModelXmap"), a:000)
     return g:model_output
 endfunction
+
+" define mapping
+function! JiebaOmapExpr(motion, model_funcname)
+    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
+endfunction
+xnoremap <expr> <silent> e JiebaXmapExpr("e", "JiebaOracleModel")
 
 " state_before setup
 let &virtualedit = "onemore"
@@ -743,6 +761,12 @@ function! JiebaOracleModel(...)
     return g:model_output
 endfunction
 
+" define mapping
+function! JiebaOmapExpr(motion, model_funcname)
+    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
+endfunction
+xnoremap <expr> <silent> e JiebaXmapExpr("e", "JiebaOracleModel")
+
 " state_before setup
 let &virtualedit = "onemore"
 call setreg("a", "foo")
@@ -791,7 +815,7 @@ endif
 
 let g:jieba_test_case_events_count = {}
 " cursor movement
-call JiebaXmap("e", 1, "JiebaOracleModel")
+normal gv1e
 execute "normal! \\<Esc>"
 
 let g:jieba_test_case_events_count_frozen = copy(g:jieba_test_case_events_count)
@@ -915,6 +939,12 @@ function! JiebaOracleModel(...)
     return g:model_output
 endfunction
 
+" define mapping
+function! JiebaOmapExpr(motion, model_funcname)
+    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
+endfunction
+onoremap <expr> <silent> W JiebaOmapExpr("W", "JiebaOracleModel")
+
 " state_before setup
 
 " buffer_before setup
@@ -981,6 +1011,12 @@ function! JiebaOracleModel(...)
     return g:model_output
 endfunction
 
+" define mapping
+function! JiebaOmapExpr(motion, model_funcname)
+    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
+endfunction
+onoremap <expr> <silent> W JiebaOmapExpr("W", "JiebaOracleModel")
+
 " state_before setup
 
 " buffer_before setup
@@ -1001,7 +1037,7 @@ augroup END
 
 let g:jieba_test_case_events_count = {}
 " cursor movement
-call JiebaOmap("W", 0, 2, "d", "a", "JiebaOracleModel")
+normal "ad2W
 execute "normal! \\<Esc>"
 
 let g:jieba_test_case_events_count_frozen = copy(g:jieba_test_case_events_count)


### PR DESCRIPTION
The purposes are twofold:

- Make `<expr>`-mappings testable.
- Make the mapping codes more readable.