### PR TITLE
Add bi verification cases for nvim as sanity check on cdylib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,12 @@ jobs:
           - distr: vim
             version: v9.1.0000
             glue-lang: py311
+          - distr: nvim
+            version: v0.11.5
+            glue-lang: lua51
+          - distr: nvim
+            version: v0.12.2
+            glue-lang: lua51
     env:
       # uv variables
       UV_PROJECT: ${{ github.workspace }}/test/jieba_test_metatest

--- a/test/cases/basic_integrated_verification/buffers.yaml
+++ b/test/cases/basic_integrated_verification/buffers.yaml
@@ -526,3 +526,13 @@ insert_eol_buffers:
   - '␊␊······|␊'
   - '␊␊······|␊␊'
   - '␊␊······␊|␊'
+
+nvim_basics:
+  buffers:
+    - 'abcd·efghi···j|kl·m···nopqr··␊'
+    - '··rqpon···m·l|kj···ihgfe·dcba␊'
+  visual_buffers:
+    - 'abcd·efghi···j[]kl·m···nopqr··␊'
+    - '··rqpon···m·l[]kj···ihgfe·dcba␊'
+    - 'abcd·efghi···j[k]l·m···nopqr··␊'
+    - '··rqpon···m·l[k]j···ihgfe·dcba␊'

--- a/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
+++ b/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
@@ -1,0 +1,103 @@
+// Copyright 2026 Kaiwen Wu. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy
+// of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+#V 5
+
+? has:nvim
+
+#X bi
+
+#E CursorMoved=
+#E CursorMovedI=
+#E CmdlineChanged=
+#E CmdlineEnter=
+#E CmdlineLeave=
+#E InsertEnter=
+#E InsertChange=
+#E InsertLeave=
+#E ModeChanged=
+#E OptionSet=
+#E TextChanged=
+#E TextChangedI=
+#E TextYankPost=
+
+{%- for key in ['w', 'e', 'b', 'ge'] %}
+  {%- for count in [0, 1, 2, 3, 4, 10293949403] %}
+    {%- for buffer in nvim_basics.buffers %}
+
+M n
+K {{ key }}
+B0 {{ buffer }}
+C {{ count }}
+      {%- for operator in ['d', 'c', 'y'] %}
+
+M o
+K {{ key }}
+O {{ operator }}
+R a
+B0 {{ buffer }}
+C {{ count }}
+S1 "a= '[= ']= '<= '>=
+      {%- endfor %}
+    {%- endfor %}
+    {%- for buffer in nvim_basics.visual_buffers %}
+      {%- for visualmode in ['v', 'V', '\\<C-v>'] %}
+
+M {{ visualmode }}
+K {{ key }}
+B0 {{ buffer }}
+C {{ count }}
+S1 visualmode()= '[= ']=
+      {%- endfor %}
+    {%- endfor %}
+  {%- endfor %}
+{%- endfor %}
+
+{%- for key in ['iw', 'aw'] %}
+  {%- for count in [0, 1, 2, 3, 4, 10293949403] %}
+    {%- for buffer in nvim_basics.buffers %}
+      {%- for operator in ['d', 'c', 'y'] %}
+
+M o
+K {{ key }}
+O {{ operator }}
+R a
+B0 {{ buffer }}
+C {{ count }}
+S1 "a= '[= ']= '<= '>=
+      {%- endfor %}
+    {%- endfor %}
+    {%- for buffer in nvim_basics.visual_buffers %}
+      {%- for visualmode in ['v', 'V', '\\<C-v>'] %}
+
+M {{ visualmode }}
+K {{ key }}
+B0 {{ buffer }}
+C {{ count }}
+S1 visualmode()= '[= ']=
+      {%- endfor %}
+    {%- endfor %}
+  {%- endfor %}
+{%- endfor %}
+
+{%- for key in ['\\<C-w>'] %}
+  {%- for buffer in nvim_basics.buffers %}
+
+M i
+S0 backspace=indent,eol,start
+K {{ key }}
+B0 {{ buffer }}
+S1 "a= '[= ']= '<= '>=
+  {%- endfor %}
+{%- endfor %}

--- a/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
+++ b/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
@@ -18,18 +18,10 @@
 
 #X bi
 
-#E CursorMoved=
-#E CursorMovedI=
-#E CmdlineChanged=
 #E CmdlineEnter=
 #E CmdlineLeave=
 #E InsertEnter=
-#E InsertChange=
 #E InsertLeave=
-#E ModeChanged=
-#E OptionSet=
-#E TextChanged=
-#E TextChangedI=
 #E TextYankPost=
 
 {%- for key in ['w', 'e', 'b', 'ge'] %}

--- a/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
+++ b/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
@@ -14,8 +14,6 @@
 
 #V 5
 
-? has:nvim
-
 #X bi
 
 #E CmdlineEnter=


### PR DESCRIPTION
This pull request adds several basic bi verification cases for nvim, primarily as a sanity check whether the lua cdylib has exposed all mappings correctly.