### PR TITLE
Keep word motion uninitialized on init failure

### DIFF
--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -91,12 +91,14 @@ function! s:InitWordMotion() abort
         let l:init_word_motion_err = luaeval("jieba_vim:init_word_motion(unpack(_A))", l:args)
         if l:init_word_motion_err !=# ""
             echoerr l:init_word_motion_err
+            return
         endif
     else
         let l:init_word_motion_err = py3eval(
             \ "jieba_vim.navigation.init_word_motion(*vim.eval('l:args'))")
         if l:init_word_motion_err !=# "" && l:init_word_motion_err !=# v:none
             echoerr l:init_word_motion_err
+            return
         endif
     endif
     let s:loaded_jieba_vim_word_motion = 1


### PR DESCRIPTION
`InitWordMotion()` reports an initialization error, but then still marks word
motion as loaded. A later motion can therefore reach an uninitialized backend.

Return after reporting the error in both glue paths, leaving the existing
uninitialized check in effect.

Tested with Vim 9.2 and `+python3`:

- a missing user dictionary now reaches the existing `word_motion uninitialized`
  error instead of the backend traceback
- normal initialization and a word motion still succeed

I did not run the Neovim/Lua path locally; the existing CI matrix covers it.