### PR TITLE
Mention vim-repeat in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@
 [vim-plug][vim-plug] (Vim / Neovim):
 
 ```vim
+Plug 'tpope/vim-repeat'
 Plug 'kkew3/jieba.vim', { 'branch': 'release', 'do': { -> jieba_vim#install() } }
 ```
 
 [lazy.nvim][lazy-nvim] (Neovim):
 
 ```lua
+{ "tpope/vim-repeat" },
 {
     "kkew3/jieba.vim",
     branch = "release",
@@ -150,12 +152,14 @@ Apache license v2；部分文件参照 [vim-LICENSE.txt](./vim-LICENSE.txt).
 [vim-plug][vim-plug] (Vim / Neovim):
 
 ```vim
+Plug 'tpope/vim-repeat'
 Plug 'kkew3/jieba.vim', { 'branch': 'release', 'do': { -> jieba_vim#install() } }
 ```
 
 [lazy.nvim][lazy-nvim] (Neovim):
 
 ```lua
+{ "tpope/vim-repeat" },
 {
     "kkew3/jieba.vim",
     branch = "release",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 
 - Vim 8/9：需要 `+python3` 或 `+python3/dyn` 或 `+python3/dyn-stable`。
 - Neovim：无额外依赖。
+- 可选：安装 [`tpope/vim-repeat`][vim-repeat] 后可用 `.` 重复上一操作。
 
 [vim-plug][vim-plug] (Vim / Neovim):
 
@@ -144,6 +145,7 @@ Apache license v2；部分文件参照 [vim-LICENSE.txt](./vim-LICENSE.txt).
 
 - Vim 8/9: require `+python3` or `+python3/dyn` or `+python3/dyn-stable`.
 - Neovim: no additional dependency.
+- Optional: install [`tpope/vim-repeat`][vim-repeat] to repeat the last operation with `.`.
 
 [vim-plug][vim-plug] (Vim / Neovim):
 


### PR DESCRIPTION
The installation section describes runtime requirements, but it does not mention the optional `vim-repeat` integration.

Add a short note to both the Chinese and English prerequisite lists.

Closes #118.