### PR TITLE
Add arrow mappings and test cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,7 +552,7 @@ jobs:
         shell: bash
         run: |
           cd rust_backend/jieba_vim_rs_core
-          cargo test -r --test golden_master -- unit-*.jsonl
+          cargo test -r --test golden_master -- -q unit-*.jsonl
 
   coverage:
     name: Test coverage

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 ## 核心特性
 
 - 混合架构：Vimscript 负责集成，Rust 核心通过 cdylib 提供高性能分词；预编译二进制托管于 [GitHub Releases][releases]，覆盖主流平台。两者通过 python3 (Vim) 或 lua5.1 (Neovim) 桥接。
-- 兼容性保障：48,000+ 自动化 Vim 用例验证，确保在纯 ASCII 文本中与原生 word motions / text objects 行为完全一致。
-- 完整支持：全部 12 个 word motions / text objects（`w` / `W` / `b` / `B` / `e` / `E` / `ge` / `gE` / `iw` / `iW` / `aw` / `aW`），覆盖 normal / visual / operator-pending 模式，支持计数前缀与所有字符操作，支持 register，以及通过 [`tpope/vim-repeat`][vim-repeat] 支持 [`.`][dot-repeat] 重复上一操作。
+- 兼容性保障：84,000+ 自动化 Vim 用例验证，确保在纯 ASCII 文本中与原生 word motions / text objects 行为完全一致。
+- 完整支持：全部 17 个 word motions / text objects（`w` / `W` / `b` / `B` / `e` / `E` / `ge` / `gE` / `CTRL-Left` / `SHIFT-Left` / `CTRL-Right` / `Shift-Right` / `iw` / `iW` / `aw` / `aW` / `i_CTRL-W`），覆盖 normal / visual / operator-pending 模式，支持计数前缀与所有字符操作，支持 register，以及通过 [`tpope/vim-repeat`][vim-repeat] 支持 [`.`][dot-repeat] 重复上一操作。
 - 灵活配置：尊重 [`'iskeyword'`][isk] 设置，允许自定义分词边界；支持惰性加载词典，按需启用。
 - 帮助文档：可使用 `:h jieba` 在 Vim/Nvim 内查看帮助。
 
@@ -55,7 +55,9 @@ Plug 'kkew3/jieba.vim', { 'branch': 'release', 'do': { -> jieba_vim#install() } 
 
 - 在保留原生语义（如 `w` 不跳过标点、`W` 跳过标点）的基础上，使以下命令识别中文词语：
   * Word motions: `b`、`B`、`ge`、`gE`、`w`、`W`、`e`、`E`
+  * Word motions 箭头键位: `CTRL-Left`、`SHIFT-Left`、`CTRL-Right`、`SHIFT-Right`
   * Text objects: `iw`、`iW`、`aw`、`aW`
+  * INSERT 模式 op: `i_CTRL-W`
 - 支持所有模式：`nmap` / `xmap` / `omap`（text object 没有 `nmap`）；
 - 支持计数：`4w`、`c2e`、`3daw` 等；
 - 支持所有字符操作：`d`、`c`、`y`、`g~` 等；
@@ -75,11 +77,11 @@ nmap <LocalLeader>jc <Plug>(Jieba_preview_cancel)
 
 另提供 `:JiebaPreviewCancel` 命令用于取消按词跳转位置预览。
 
-> 当前暂不支持预览 text objects。
+> 当前暂不支持预览 text objects 和箭头键位。
 
 ### 非侵入式设计
 
-默认**不映射任何按键**，通过 `<Plug>(Jieba_*)` 映射与命令供用户自由配置。若希望快速启用默认行为（不包括跳转预览），可在 `~/.vimrc` 中：
+默认**不映射任何按键**，通过 `<Plug>(Jieba_*)` 映射与命令供用户自由配置。若希望快速启用默认行为（不包括跳转预览和实验性功能），可在 `~/.vimrc` 中：
 
 ```vim
 let g:jieba_vim_keymap = 1
@@ -136,8 +138,8 @@ Apache license v2；部分文件参照 [vim-LICENSE.txt](./vim-LICENSE.txt).
 ## Core Features
 
 - Hybrid Architecture: Vimscript handles integration while the Rust core delivers high-performance word segmentation via cdylib; precompiled binaries are hosted on [GitHub Releases][releases], covering major platforms. Rust and Vimscript are bridged by python3 (Vim) or lua5.1 (Neovim).
-- Compatibility Assurance: 48,000+ automated Vim test cases ensure behavior fully consistent with native word motions / text objects when handling pure ASCII text.
-- Complete Support: All 12 word motions / text objects (`w` / `W` / `b` / `B` / `e` / `E` / `ge` / `gE` / `iw` / `iW` / `aw` / `aW`), covering normal / visual / operator-pending modes, supporting count prefixes and all character operators, supporting registers, and supporting [`.`][dot-repeat] to repeat the last operation via [tpope/vim-repeat][vim-repeat].
+- Compatibility Assurance: 84,000+ automated Vim test cases ensure behavior fully consistent with native word motions / text objects when handling pure ASCII text.
+- Complete Support: All 17 word motions / text objects (`w` / `W` / `b` / `B` / `e` / `E` / `ge` / `gE` / `CTRL-Left` / `SHIFT-Left` / `CTRL-Right` / `Shift-Right` / `iw` / `iW` / `aw` / `aW` / `i_CTRL-W`), covering normal / visual / operator-pending modes, supporting count prefixes and all character operators, supporting registers, and supporting [`.`][dot-repeat] to repeat the last operation via [tpope/vim-repeat][vim-repeat].
 - Flexible Configuration: Respects [`'iskeyword'`][isk] settings, allowing custom word boundary definitions; supports lazy-loading dictionaries, enabling on-demand activation.
 - Help documentation: Check the help documentation with `:h jieba` within Vim/Nvim.
 
@@ -179,7 +181,9 @@ Here, `jieba_vim#install()` prioritizes downloading the precompiled cdylib, fall
 
 - While preserving native semantics (e.g., `w` does not skip punctuation, whereas `W` does), the following commands are enhanced to recognize Chinese words:
   * Word motions: `b`、`B`、`ge`、`gE`、`w`、`W`、`e`、`E`
+  * Word motion arrow mappings: `CTRL-Left`、`SHIFT-Left`、`CTRL-Right`、`SHIFT-Right`
   * Text objects: `iw`、`iW`、`aw`、`aW`
+  * INSERT mode op: `i_CTRL-W`
 - Supports all modes: `nmap` / `xmap` / `omap` (text objects have no `nmap`);
 - Supports counts: `4w`, `c2e`, `3daw`, etc.;
 - Supports all character operators: `d`, `c`, `y`, `g~`, etc.;
@@ -199,11 +203,11 @@ nmap <LocalLeader>jc <Plug>(Jieba_preview_cancel)
 
 Additionally, the `:JiebaPreviewCancel` command is provided to cancel word motion previews.
 
-> Preview for text objects is currently not supported.
+> Preview for text objects and arrow mappings is currently not supported.
 
 ### Non-intrusive Design
 
-By default, no keys are mapped; users can freely configure via `<Plug>(Jieba_*)` mappings and commands. If you wish to quickly enable default behavior (excluding cursor movement preview), add the following to `~/.vimrc`:
+By default, no keys are mapped; users can freely configure via `<Plug>(Jieba_*)` mappings and commands. If you wish to quickly enable default behavior (excluding cursor movement preview and experimental features), add the following to `~/.vimrc`:
 
 ```vim
 let g:jieba_vim_keymap = 1

--- a/lua/jieba_vim/init.lua
+++ b/lua/jieba_vim/init.lua
@@ -66,8 +66,8 @@ function M.omap(self, buffer, motion, cursor, count, operator)
     return self.word_motion:omap(buffer, motion, cursor, count, operator)
 end
 
-function M.imap_ctrl_w(self, buffer, cursor)
-    return self.word_motion:imap_ctrl_w(buffer, cursor)
+function M.imap(self, buffer, motion, cursor)
+    return self.word_motion:imap(buffer, motion, cursor)
 end
 
 function M.preview_nmap(self, buffer, motion, cursor, preview_limit)

--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -239,7 +239,7 @@ function! JiebaModelOmap(...)
     endif
 endfunction
 
-function! s:JiebaModelImapCtrlW(...)
+function! JiebaModelImap(...)
     if !s:loaded_jieba_vim_cdylib
         throw "cdylib unloaded; run jieba_vim#install() first"
     endif
@@ -248,18 +248,10 @@ function! s:JiebaModelImapCtrlW(...)
     endif
 
     if has("nvim")
-        return luaeval("jieba_vim:imap_ctrl_w(jieba_vim.buffer, unpack(_A))", a:000)
+        return luaeval("jieba_vim:imap(jieba_vim.buffer, unpack(_A))", a:000)
     else
         return py3eval(
-            \ "jieba_vim.navigation.imap_ctrl_w(vim.current.buffer, *vim.eval('a:000'))")
-    endif
-endfunction
-
-function! JiebaModelImap(motion, ...)
-    if a:motion ==# "\<C-w>"
-        return call(function("<SID>JiebaModelImapCtrlW"), a:000)
-    else
-        return call(function("JiebaModelNmap"), [a:motion, a:1, 1])
+            \ "jieba_vim.navigation.imap(vim.current.buffer, *vim.eval('a:000'))")
     endif
 endfunction
 
@@ -490,22 +482,11 @@ function! s:JiebaImapCtrlWExpr(model_funcname)
 endfunction
 
 function! s:JiebaImapArrowExpr(motion, model_funcname)
-    if a:motion ==# "\<C-Left>"
-        let l:equiv_motion = "B"
-    elseif a:motion ==# "\<S-Left>"
-        let l:equiv_motion = "b"
-    elseif a:motion ==# "\<C-Right>"
-        let l:equiv_motion = "W"
-    elseif a:motion ==# "\<S-Right>"
-        let l:equiv_motion = "w"
-    else
-        let l:equiv_motion = a:motion
-    endif
     let l:curpos = getcurpos()
     if a:model_funcname !=# ""
-        let l:result_dict = function(a:model_funcname)(l:equiv_motion, l:curpos)
+        let l:result_dict = function(a:model_funcname)(a:motion, l:curpos)
     else
-        let l:result_dict = JiebaModelImap(l:equiv_motion, l:curpos)
+        let l:result_dict = JiebaModelImap(a:motion, l:curpos)
     endif
     return "\<Cmd>call cursor("
         \ . l:result_dict["cursor"][1] . ","

--- a/plugin/jieba_vim.vim
+++ b/plugin/jieba_vim.vim
@@ -258,6 +258,8 @@ endfunction
 function! JiebaModelImap(motion, ...)
     if a:motion ==# "\<C-w>"
         return call(function("<SID>JiebaModelImapCtrlW"), a:000)
+    else
+        return call(function("JiebaModelNmap"), [a:motion, a:1, 1])
     endif
 endfunction
 
@@ -487,21 +489,74 @@ function! s:JiebaImapCtrlWExpr(model_funcname)
     endif
 endfunction
 
+function! s:JiebaImapArrowExpr(motion, model_funcname)
+    if a:motion ==# "\<C-Left>"
+        let l:equiv_motion = "B"
+    elseif a:motion ==# "\<S-Left>"
+        let l:equiv_motion = "b"
+    elseif a:motion ==# "\<C-Right>"
+        let l:equiv_motion = "W"
+    elseif a:motion ==# "\<S-Right>"
+        let l:equiv_motion = "w"
+    else
+        let l:equiv_motion = a:motion
+    endif
+    let l:curpos = getcurpos()
+    if a:model_funcname !=# ""
+        let l:result_dict = function(a:model_funcname)(l:equiv_motion, l:curpos)
+    else
+        let l:result_dict = JiebaModelImap(l:equiv_motion, l:curpos)
+    endif
+    return "\<Cmd>call cursor("
+        \ . l:result_dict["cursor"][1] . ","
+        \ . l:result_dict["cursor"][2] . ")\<CR>"
+endfunction
+
 function! JiebaNmapExpr(motion, model_funcname)
-    return "\<Cmd>call JiebaNmap('" . a:motion . "', v:count1, '" . a:model_funcname . "')\<CR>"
+    if a:motion ==# "\<C-Left>"
+        let l:equiv_motion = "B"
+    elseif a:motion ==# "\<S-Left>"
+        let l:equiv_motion = "b"
+    elseif a:motion ==# "\<C-Right>"
+        let l:equiv_motion = "W"
+    elseif a:motion ==# "\<S-Right>"
+        let l:equiv_motion = "w"
+    else
+        let l:equiv_motion = a:motion
+    endif
+    return "\<Cmd>call JiebaNmap('" . l:equiv_motion . "', v:count1, '" . a:model_funcname . "')\<CR>"
 endfunction
 
 for ky in s:motions
     execute 'nnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') JiebaNmapExpr("' . ky . '", "")'
 endfor
+nnoremap <expr> <silent> <Plug>(Jieba_C_Left) JiebaNmapExpr("\<C-Left>", "")
+nnoremap <expr> <silent> <Plug>(Jieba_S_Left) JiebaNmapExpr("\<S-Left>", "")
+nnoremap <expr> <silent> <Plug>(Jieba_C_Right) JiebaNmapExpr("\<C-Right>", "")
+nnoremap <expr> <silent> <Plug>(Jieba_S_Right) JiebaNmapExpr("\<S-Right>", "")
 
 function! JiebaXmapExpr(motion, model_funcname)
-    return "\<Cmd>call JiebaXmap('" . a:motion . "', v:count1, '" . a:model_funcname . "')\<CR>"
+    if a:motion ==# "\<C-Left>"
+        let l:equiv_motion = "B"
+    elseif a:motion ==# "\<S-Left>"
+        let l:equiv_motion = "b"
+    elseif a:motion ==# "\<C-Right>"
+        let l:equiv_motion = "W"
+    elseif a:motion ==# "\<S-Right>"
+        let l:equiv_motion = "w"
+    else
+        let l:equiv_motion = a:motion
+    endif
+    return "\<Cmd>call JiebaXmap('" . l:equiv_motion . "', v:count1, '" . a:model_funcname . "')\<CR>"
 endfunction
 
 for ky in s:motions + s:objects
     execute 'xnoremap <expr> <silent> <Plug>(Jieba_' . ky . ') JiebaXmapExpr("' . ky . '", "")'
 endfor
+xnoremap <expr> <silent> <Plug>(Jieba_C_Left) JiebaXmapExpr("\<C-Left>", "")
+xnoremap <expr> <silent> <Plug>(Jieba_S_Left) JiebaXmapExpr("\<S-Left>", "")
+xnoremap <expr> <silent> <Plug>(Jieba_C_Right) JiebaXmapExpr("\<C-Right>", "")
+xnoremap <expr> <silent> <Plug>(Jieba_S_Right) JiebaXmapExpr("\<S-Right>", "")
 
 function! JiebaOmapRepeat(motion, repeat, count, operator, register, model_funcname)
     let l:result_dict = s:JiebaModelOmapProcessed(a:model_funcname, a:motion, getcurpos(), a:count, a:operator)
@@ -515,22 +570,50 @@ function! JiebaOmapRepeat(motion, repeat, count, operator, register, model_funcn
 endfunction
 
 function! JiebaOmapRepeatExpr(motion, repeat, model_funcname)
-    return "\<Esc>\<Cmd>call JiebaOmapRepeat('" . a:motion . "', " . a:repeat . ", " . v:count1 . ", '" . v:operator . "', '" . v:register . "', '" . a:model_funcname . "')\<CR>"
+    if a:motion ==# "\<C-Left>"
+        let l:equiv_motion = "B"
+    elseif a:motion ==# "\<S-Left>"
+        let l:equiv_motion = "b"
+    elseif a:motion ==# "\<C-Right>"
+        let l:equiv_motion = "W"
+    elseif a:motion ==# "\<S-Right>"
+        let l:equiv_motion = "w"
+    else
+        let l:equiv_motion = a:motion
+    endif
+    return "\<Esc>\<Cmd>call JiebaOmapRepeat('" . l:equiv_motion . "', " . a:repeat . ", " . v:count1 . ", '" . v:operator . "', '" . v:register . "', '" . a:model_funcname . "')\<CR>"
+endfunction
+
+function! JiebaOmapExpr(motion, model_funcname)
+    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
 endfunction
 
 for ky in s:motions + s:objects
     execute 'onoremap <expr> <silent> <Plug>(Jieba_internal_o_' . ky . ') JiebaOmapRepeatExpr("' . ky . '", 1, "")'
-    execute 'onoremap <expr> <silent> <Plug>(Jieba_' . ky . ') JiebaOmapRepeatExpr("' . ky . '", 0, "")'
+    execute 'onoremap <expr> <silent> <Plug>(Jieba_' . ky . ') JiebaOmapExpr("' . ky . '", "")'
 endfor
+onoremap <expr> <silent> <Plug>(Jieba_internal_o_C_Left) JiebaOmapRepeatExpr("\<C-Left>", 1, "")
+onoremap <expr> <silent> <Plug>(Jieba_internal_o_S_Left) JiebaOmapRepeatExpr("\<S-Left>", 1, "")
+onoremap <expr> <silent> <Plug>(Jieba_internal_o_C_Right) JiebaOmapRepeatExpr("\<C-Right>", 1, "")
+onoremap <expr> <silent> <Plug>(Jieba_internal_o_S_Right) JiebaOmapRepeatExpr("\<S-Right>", 1, "")
+onoremap <expr> <silent> <Plug>(Jieba_C_Left) JiebaOmapExpr("\<C-Left>", "")
+onoremap <expr> <silent> <Plug>(Jieba_S_Left) JiebaOmapExpr("\<S-Left>", "")
+onoremap <expr> <silent> <Plug>(Jieba_C_Right) JiebaOmapExpr("\<C-Right>", "")
+onoremap <expr> <silent> <Plug>(Jieba_S_Right) JiebaOmapExpr("\<S-Right>", "")
 
 function! JiebaImapExpr(motion, model_funcname)
     if a:motion ==# "\<C-w>"
         return s:JiebaImapCtrlWExpr(a:model_funcname)
+    else
+        return s:JiebaImapArrowExpr(a:motion, a:model_funcname)
     endif
-    throw "invalid motion"
 endfunction
 
 inoremap <expr> <silent> <Plug>(Jieba_C_w) JiebaImapExpr("\<C-w>", "")
+inoremap <expr> <silent> <Plug>(Jieba_C_Left) JiebaImapExpr("\<C-Left>", "")
+inoremap <expr> <silent> <Plug>(Jieba_S_Left) JiebaImapExpr("\<S-Left>", "")
+inoremap <expr> <silent> <Plug>(Jieba_C_Right) JiebaImapExpr("\<C-Right>", "")
+inoremap <expr> <silent> <Plug>(Jieba_S_Right) JiebaImapExpr("\<S-Right>", "")
 
 let s:modes = ["n", "x", "o"]
 if g:jieba_vim_keymap
@@ -538,6 +621,12 @@ if g:jieba_vim_keymap
         for md in s:modes
             execute md . "map " . ky . " <Plug>(Jieba_" . ky . ")"
         endfor
+    endfor
+    for md in s:modes
+        execute md . "map <C-Left> <Plug>(Jieba_C_Left)"
+        execute md . "map <S-Left> <Plug>(Jieba_S_Left)"
+        execute md . "map <C-Right> <Plug>(Jieba_C_Right)"
+        execute md . "map <S-Right> <Plug>(Jieba_S_Right)"
     endfor
     for ky in s:objects
         for md in s:modes

--- a/pythonx/jieba_vim/navigation.py
+++ b/pythonx/jieba_vim/navigation.py
@@ -19,7 +19,7 @@ word_motion = None
 
 def as_bytes(s):
     if isinstance(s, str):
-        return s.encode("utf-8")
+        return s.encode("utf-8", errors="surrogateescape")
     return s
 
 

--- a/pythonx/jieba_vim/navigation.py
+++ b/pythonx/jieba_vim/navigation.py
@@ -75,9 +75,10 @@ def omap(buffer, motion, cursor, count, operator):
     return word_motion.omap(buffer, motion, cursor, count, operator)
 
 
-def imap_ctrl_w(buffer, cursor):
+def imap(buffer, motion, cursor):
+    motion = as_bytes(motion)
     cursor = ints(cursor)
-    return word_motion.imap_ctrl_w(buffer, cursor)
+    return word_motion.imap(buffer, motion, cursor)
 
 
 def preview_nmap(buffer, motion, cursor, preview_limit):

--- a/rust_backend/Cargo.lock
+++ b/rust_backend/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "jieba_vim_rs_binding_lua51"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "jieba-rs",
  "jieba_vim_rs_core",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "jieba_vim_rs_binding_py3"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "jieba-rs",
  "jieba_vim_rs_core",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "jieba_vim_rs_core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bstr",
  "clap",

--- a/rust_backend/jieba_vim_rs_binding_lua51/Cargo.toml
+++ b/rust_backend/jieba_vim_rs_binding_lua51/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jieba_vim_rs_binding_lua51"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [lib]

--- a/rust_backend/jieba_vim_rs_binding_lua51/src/wrappers.rs
+++ b/rust_backend/jieba_vim_rs_binding_lua51/src/wrappers.rs
@@ -19,7 +19,7 @@ use std::sync::OnceLock;
 use jieba_rs::Jieba;
 use jieba_vim_rs_core::BufferLike;
 use jieba_vim_rs_core::motion::{
-    ImapCtrlWOutput, NmapOutput, OmapOutput, WordMotion, XmapOutput,
+    ImapOutput, NmapOutput, OmapOutput, WordMotion, XmapOutput,
 };
 use jieba_vim_rs_core::token::{JiebaPlaceholder, Tokenizer};
 use mlua::{IntoLua, Lua, ObjectLike, Table, UserData, UserDataMethods, Value};
@@ -120,9 +120,9 @@ impl IntoLua for OmapOutputWrapper {
     }
 }
 
-pub struct ImapCtrlWOutputWrapper(ImapCtrlWOutput);
+pub struct ImapOutputWrapper(ImapOutput);
 
-impl IntoLua for ImapCtrlWOutputWrapper {
+impl IntoLua for ImapOutputWrapper {
     fn into_lua(self, lua: &Lua) -> mlua::prelude::LuaResult<Value> {
         let table = lua.create_table()?;
         table.set("cursor", self.0.cursor)?;
@@ -272,11 +272,11 @@ impl WordMotionWrapper {
         )?))
     }
 
-    fn imap_ctrl_w(
+    fn imap(
         _lua: &Lua,
         this: &mut Self,
-        (buffer, cursor): (Table, Vec<usize>),
-    ) -> mlua::Result<ImapCtrlWOutputWrapper> {
+        (buffer, motion, cursor): (Table, String, Vec<usize>),
+    ) -> mlua::Result<ImapOutputWrapper> {
         if cursor.len() != 5 {
             return Err(mlua::Error::runtime(
                 "cursor must contain exactly 5 elements",
@@ -285,9 +285,11 @@ impl WordMotionWrapper {
         let buffer = TableBufferWrapper(buffer);
         let mut cursor_arr = [0usize; 5];
         cursor_arr.copy_from_slice(&cursor);
-        Ok(ImapCtrlWOutputWrapper(
-            this.wm.imap_ctrl_w(&buffer, cursor_arr)?,
-        ))
+        Ok(ImapOutputWrapper(this.wm.imap(
+            &buffer,
+            motion.as_bytes(),
+            cursor_arr,
+        )?))
     }
 
     fn preview_nmap(
@@ -337,7 +339,7 @@ impl UserData for WordMotionWrapper {
         methods.add_method_mut("nmap", Self::nmap);
         methods.add_method_mut("xmap", Self::xmap);
         methods.add_method_mut("omap", Self::omap);
-        methods.add_method_mut("imap_ctrl_w", Self::imap_ctrl_w);
+        methods.add_method_mut("imap", Self::imap);
         methods.add_method_mut("preview_nmap", Self::preview_nmap);
     }
 }
@@ -478,11 +480,11 @@ impl LazyWordMotionWrapper {
         )?))
     }
 
-    fn imap_ctrl_w(
+    fn imap(
         _lua: &Lua,
         this: &mut Self,
-        (buffer, cursor): (Table, Vec<usize>),
-    ) -> mlua::Result<ImapCtrlWOutputWrapper> {
+        (buffer, motion, cursor): (Table, String, Vec<usize>),
+    ) -> mlua::Result<ImapOutputWrapper> {
         if cursor.len() != 5 {
             return Err(mlua::Error::runtime(
                 "cursor must contain exactly 5 elements",
@@ -491,9 +493,11 @@ impl LazyWordMotionWrapper {
         let buffer = TableBufferWrapper(buffer);
         let mut cursor_arr = [0usize; 5];
         cursor_arr.copy_from_slice(&cursor);
-        Ok(ImapCtrlWOutputWrapper(
-            this.wm.imap_ctrl_w(&buffer, cursor_arr)?,
-        ))
+        Ok(ImapOutputWrapper(this.wm.imap(
+            &buffer,
+            motion.as_bytes(),
+            cursor_arr,
+        )?))
     }
 
     fn preview_nmap(
@@ -543,7 +547,7 @@ impl UserData for LazyWordMotionWrapper {
         methods.add_method_mut("nmap", Self::nmap);
         methods.add_method_mut("xmap", Self::xmap);
         methods.add_method_mut("omap", Self::omap);
-        methods.add_method_mut("imap_ctrl_w", Self::imap_ctrl_w);
+        methods.add_method_mut("imap", Self::imap);
         methods.add_method_mut("preview_nmap", Self::preview_nmap);
     }
 }

--- a/rust_backend/jieba_vim_rs_binding_lua51/src/wrappers.rs
+++ b/rust_backend/jieba_vim_rs_binding_lua51/src/wrappers.rs
@@ -275,7 +275,7 @@ impl WordMotionWrapper {
     fn imap(
         _lua: &Lua,
         this: &mut Self,
-        (buffer, motion, cursor): (Table, String, Vec<usize>),
+        (buffer, motion, cursor): (Table, mlua::String, Vec<usize>),
     ) -> mlua::Result<ImapOutputWrapper> {
         if cursor.len() != 5 {
             return Err(mlua::Error::runtime(
@@ -287,7 +287,7 @@ impl WordMotionWrapper {
         cursor_arr.copy_from_slice(&cursor);
         Ok(ImapOutputWrapper(this.wm.imap(
             &buffer,
-            motion.as_bytes(),
+            &motion.as_bytes(),
             cursor_arr,
         )?))
     }
@@ -483,7 +483,7 @@ impl LazyWordMotionWrapper {
     fn imap(
         _lua: &Lua,
         this: &mut Self,
-        (buffer, motion, cursor): (Table, String, Vec<usize>),
+        (buffer, motion, cursor): (Table, mlua::String, Vec<usize>),
     ) -> mlua::Result<ImapOutputWrapper> {
         if cursor.len() != 5 {
             return Err(mlua::Error::runtime(
@@ -495,7 +495,7 @@ impl LazyWordMotionWrapper {
         cursor_arr.copy_from_slice(&cursor);
         Ok(ImapOutputWrapper(this.wm.imap(
             &buffer,
-            motion.as_bytes(),
+            &motion.as_bytes(),
             cursor_arr,
         )?))
     }

--- a/rust_backend/jieba_vim_rs_binding_py3/Cargo.toml
+++ b/rust_backend/jieba_vim_rs_binding_py3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jieba_vim_rs_binding_py3"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust_backend/jieba_vim_rs_binding_py3/src/wrappers.rs
+++ b/rust_backend/jieba_vim_rs_binding_py3/src/wrappers.rs
@@ -19,7 +19,7 @@ use std::sync::OnceLock;
 use jieba_rs::Jieba;
 use jieba_vim_rs_core::BufferLike;
 use jieba_vim_rs_core::motion::{
-    ImapCtrlWOutput, NmapOutput, OmapOutput, WordMotion, XmapOutput,
+    ImapOutput, NmapOutput, OmapOutput, WordMotion, XmapOutput,
 };
 use jieba_vim_rs_core::token::{JiebaPlaceholder, Tokenizer};
 use pyo3::exceptions::{PyIOError, PyValueError};
@@ -151,9 +151,9 @@ impl<'py> IntoPyObject<'py> for OmapOutputWrapper {
     }
 }
 
-pub struct ImapCtrlWOutputWrapper(ImapCtrlWOutput);
+pub struct ImapOutputWrapper(ImapOutput);
 
-impl<'py> IntoPyObject<'py> for ImapCtrlWOutputWrapper {
+impl<'py> IntoPyObject<'py> for ImapOutputWrapper {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
@@ -296,11 +296,12 @@ impl WordMotionWrapper {
         )?))
     }
 
-    pub fn imap_ctrl_w(
+    pub fn imap(
         &mut self,
         buffer: &Bound<'_, PyAny>,
+        motion: &[u8],
         cursor: Vec<usize>,
-    ) -> PyResult<ImapCtrlWOutputWrapper> {
+    ) -> PyResult<ImapOutputWrapper> {
         if cursor.len() != 5 {
             return Err(PyValueError::new_err(
                 "cursor must contain exactly 5 elements",
@@ -308,9 +309,11 @@ impl WordMotionWrapper {
         }
         let mut cursor_arr = [0usize; 5];
         cursor_arr.copy_from_slice(&cursor);
-        Ok(ImapCtrlWOutputWrapper(
-            self.wm.imap_ctrl_w(&BoundWrapper(buffer), cursor_arr)?,
-        ))
+        Ok(ImapOutputWrapper(self.wm.imap(
+            &BoundWrapper(buffer),
+            motion,
+            cursor_arr,
+        )?))
     }
 
     pub fn preview_nmap(
@@ -464,11 +467,12 @@ impl LazyWordMotionWrapper {
         )?))
     }
 
-    pub fn imap_ctrl_w(
+    pub fn imap(
         &mut self,
         buffer: &Bound<'_, PyAny>,
+        motion: &[u8],
         cursor: Vec<usize>,
-    ) -> PyResult<ImapCtrlWOutputWrapper> {
+    ) -> PyResult<ImapOutputWrapper> {
         if cursor.len() != 5 {
             return Err(PyValueError::new_err(
                 "cursor must contain exactly 5 elements",
@@ -476,9 +480,11 @@ impl LazyWordMotionWrapper {
         }
         let mut cursor_arr = [0usize; 5];
         cursor_arr.copy_from_slice(&cursor);
-        Ok(ImapCtrlWOutputWrapper(
-            self.wm.imap_ctrl_w(&BoundWrapper(buffer), cursor_arr)?,
-        ))
+        Ok(ImapOutputWrapper(self.wm.imap(
+            &BoundWrapper(buffer),
+            motion,
+            cursor_arr,
+        )?))
     }
 
     pub fn preview_nmap(

--- a/rust_backend/jieba_vim_rs_core/Cargo.toml
+++ b/rust_backend/jieba_vim_rs_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jieba_vim_rs_core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 
 [dependencies]
@@ -19,3 +19,7 @@ bstr = "1.12.1"
 [[test]]
 name = "golden_master"
 harness = false
+
+[[test]]
+name = "imap_arrow"
+harness = true

--- a/rust_backend/jieba_vim_rs_core/src/motion/api.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/api.rs
@@ -325,9 +325,7 @@ impl<C: JiebaPlaceholder> WordMotion<C> {
     ) -> Result<ffi::ImapOutput, B::Error> {
         let output = match motion {
             // \<C-W>
-            b"\x17" | b"\\u0017" => {
-                self.imap_ctrl_w_helper(buffer, cursor.into())
-            }
+            b"\x17" | b"\\u0017" => self.imap_ctrl_w(buffer, cursor.into()),
             // \<C-Left>. Also accepting double-backslash version due to json-
             // decoding issue in Vim. Same below.
             b"\x80\xfdU" | b"\\u0080\\u00fdU" | b"\\\\u0080\\\\u00fdU" => {

--- a/rust_backend/jieba_vim_rs_core/src/motion/api.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/api.rs
@@ -48,7 +48,7 @@ pub mod ffi {
         pub prevent_change: &'static [u8],
     }
 
-    pub struct ImapCtrlWOutput {
+    pub struct ImapOutput {
         pub cursor: Position,
     }
 }
@@ -115,7 +115,7 @@ mod inner {
         pub prevent_change: bool,
     }
 
-    pub struct ImapCtrlWOutput {
+    pub struct ImapOutput {
         pub cursor: Position,
     }
 
@@ -165,8 +165,8 @@ mod inner {
         }
     }
 
-    impl From<ImapCtrlWOutput> for ffi::ImapCtrlWOutput {
-        fn from(value: ImapCtrlWOutput) -> Self {
+    impl From<ImapOutput> for ffi::ImapOutput {
+        fn from(value: ImapOutput) -> Self {
             Self {
                 cursor: value.cursor.into(),
             }
@@ -175,7 +175,7 @@ mod inner {
 }
 
 pub(crate) use inner::{
-    ImapCtrlWOutput, MotionType, NmapOutput, OmapOutput, VisualMode, XmapOutput,
+    ImapOutput, MotionType, NmapOutput, OmapOutput, VisualMode, XmapOutput,
 };
 
 impl<C> WordMotion<C> {
@@ -317,11 +317,35 @@ impl<C: JiebaPlaceholder> WordMotion<C> {
         Ok(output.into())
     }
 
-    pub fn imap_ctrl_w<B: BufferLike + ?Sized>(
+    pub fn imap<B: BufferLike + ?Sized>(
         &mut self,
         buffer: &B,
+        motion: &[u8],
         cursor: ffi::CursorPositionCurswant,
-    ) -> Result<ffi::ImapCtrlWOutput, B::Error> {
-        Ok(self.imap_ctrl_w_helper(buffer, cursor.into())?.into())
+    ) -> Result<ffi::ImapOutput, B::Error> {
+        let output = match motion {
+            // \<C-W>
+            b"\x17" | b"\\u0017" => {
+                self.imap_ctrl_w_helper(buffer, cursor.into())
+            }
+            // \<C-Left>
+            b"\x80\xfdU" | b"\\u0080\\u00fdU" => {
+                self.imap_ctrl_left(buffer, cursor.into())
+            }
+            // \<C-Right>
+            b"\x80\xfdV" | b"\\u0080\\u00fdV" => {
+                self.imap_ctrl_right(buffer, cursor.into())
+            }
+            // \<S-Left>
+            b"\x80#4" | b"\\u0080#4" => {
+                self.imap_shift_left(buffer, cursor.into())
+            }
+            // \<S-Right>
+            b"\x80%i" | b"\\u0080%i" => {
+                self.imap_shift_right(buffer, cursor.into())
+            }
+            _ => unreachable!("invalid motion key sequence: {:?}", motion),
+        }?;
+        Ok(output.into())
     }
 }

--- a/rust_backend/jieba_vim_rs_core/src/motion/api.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/api.rs
@@ -328,20 +328,21 @@ impl<C: JiebaPlaceholder> WordMotion<C> {
             b"\x17" | b"\\u0017" => {
                 self.imap_ctrl_w_helper(buffer, cursor.into())
             }
-            // \<C-Left>
-            b"\x80\xfdU" | b"\\u0080\\u00fdU" => {
+            // \<C-Left>. Also accepting double-backslash version due to json-
+            // decoding issue in Vim. Same below.
+            b"\x80\xfdU" | b"\\u0080\\u00fdU" | b"\\\\u0080\\\\u00fdU" => {
                 self.imap_ctrl_left(buffer, cursor.into())
             }
             // \<C-Right>
-            b"\x80\xfdV" | b"\\u0080\\u00fdV" => {
+            b"\x80\xfdV" | b"\\u0080\\u00fdV" | b"\\\\u0080\\\\u00fdV" => {
                 self.imap_ctrl_right(buffer, cursor.into())
             }
             // \<S-Left>
-            b"\x80#4" | b"\\u0080#4" => {
+            b"\x80#4" | b"\\u0080#4" | b"\\\\u0080#4" => {
                 self.imap_shift_left(buffer, cursor.into())
             }
             // \<S-Right>
-            b"\x80%i" | b"\\u0080%i" => {
+            b"\x80%i" | b"\\u0080%i" | b"\\\\u0080%i" => {
                 self.imap_shift_right(buffer, cursor.into())
             }
             _ => unreachable!("invalid motion key sequence: {:?}", motion),

--- a/rust_backend/jieba_vim_rs_core/src/motion/imap_c_left.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/imap_c_left.rs
@@ -13,23 +13,28 @@
 // under the License.
 
 use crate::BufferLike;
-use crate::motion::core::motion::Motion;
 use crate::token::JiebaPlaceholder;
 
 use super::api::{ImapOutput, WordMotion};
 use super::core::buffer::ParsedBuffer;
+use super::core::motion::Motion;
 use super::core::position::Position;
-use super::primitives::text_object::PreviousWord;
+use super::primitives::text_object::BackwardWord;
 
 impl<C: JiebaPlaceholder> WordMotion<C> {
-    /// Delete the word before the cursor.
-    pub(crate) fn imap_ctrl_w_helper<B: BufferLike + ?Sized>(
+    /// Vim motion `C-Left` in insert mode. Take in `cursor` (0, lnum, col,
+    /// off, _), and return the new cursor position.
+    ///
+    /// # Basics
+    ///
+    /// Equivalent to `B` in normal mode, except that the motion never fails.
+    pub fn imap_ctrl_left<B: BufferLike + ?Sized>(
         &self,
         buffer: &B,
         mut cursor: Position,
     ) -> Result<ImapOutput, B::Error> {
-        let mut buffer = ParsedBuffer::new(buffer, &self.tokenizer, true);
-        let mut motion = PreviousWord::default();
+        let mut buffer = ParsedBuffer::new(buffer, &self.tokenizer, false);
+        let mut motion = BackwardWord::new(false);
         let _ = motion.map(&mut buffer, 1, &mut cursor)?;
         Ok(ImapOutput { cursor })
     }

--- a/rust_backend/jieba_vim_rs_core/src/motion/imap_c_right.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/imap_c_right.rs
@@ -13,24 +13,35 @@
 // under the License.
 
 use crate::BufferLike;
-use crate::motion::core::motion::Motion;
 use crate::token::JiebaPlaceholder;
 
 use super::api::{ImapOutput, WordMotion};
 use super::core::buffer::ParsedBuffer;
+use super::core::motion::Motion;
 use super::core::position::Position;
-use super::primitives::text_object::PreviousWord;
+use super::primitives::text_object::ForwardWord;
 
 impl<C: JiebaPlaceholder> WordMotion<C> {
-    /// Delete the word before the cursor.
-    pub(crate) fn imap_ctrl_w_helper<B: BufferLike + ?Sized>(
+    /// Vim motion `C-Right` in insert mode. Take in `cursor` (0, lnum, col,
+    /// off, _), and return the new cursor position.
+    ///
+    /// # Basics
+    ///
+    /// Equivalent to `W` in normal mode, except that the motion never fails.
+    pub fn imap_ctrl_right<B: BufferLike + ?Sized>(
         &self,
         buffer: &B,
         mut cursor: Position,
     ) -> Result<ImapOutput, B::Error> {
-        let mut buffer = ParsedBuffer::new(buffer, &self.tokenizer, true);
-        let mut motion = PreviousWord::default();
-        let _ = motion.map(&mut buffer, 1, &mut cursor)?;
+        let mut buffer = ParsedBuffer::new(buffer, &self.tokenizer, false);
+        let mut motion_eol = ForwardWord::new(true);
+        let mut motion_noeol = ForwardWord::new(false);
+        let mut cursor_copy = cursor;
+        let _ = motion_eol.map(&mut buffer, 1, &mut cursor)?;
+        let _ = motion_noeol.map(&mut buffer, 1, &mut cursor_copy)?;
+        if cursor_copy > cursor {
+            cursor = cursor_copy;
+        }
         Ok(ImapOutput { cursor })
     }
 }

--- a/rust_backend/jieba_vim_rs_core/src/motion/imap_c_w.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/imap_c_w.rs
@@ -23,7 +23,7 @@ use super::primitives::text_object::PreviousWord;
 
 impl<C: JiebaPlaceholder> WordMotion<C> {
     /// Delete the word before the cursor.
-    pub(crate) fn imap_ctrl_w_helper<B: BufferLike + ?Sized>(
+    pub fn imap_ctrl_w<B: BufferLike + ?Sized>(
         &self,
         buffer: &B,
         mut cursor: Position,

--- a/rust_backend/jieba_vim_rs_core/src/motion/imap_s_left.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/imap_s_left.rs
@@ -13,23 +13,28 @@
 // under the License.
 
 use crate::BufferLike;
-use crate::motion::core::motion::Motion;
 use crate::token::JiebaPlaceholder;
 
 use super::api::{ImapOutput, WordMotion};
 use super::core::buffer::ParsedBuffer;
+use super::core::motion::Motion;
 use super::core::position::Position;
-use super::primitives::text_object::PreviousWord;
+use super::primitives::text_object::BackwardWord;
 
 impl<C: JiebaPlaceholder> WordMotion<C> {
-    /// Delete the word before the cursor.
-    pub(crate) fn imap_ctrl_w_helper<B: BufferLike + ?Sized>(
+    /// Vim motion `S-Left` in insert mode. Take in `cursor` (0, lnum, col,
+    /// off, _), and return the new cursor position.
+    ///
+    /// # Basics
+    ///
+    /// Equivalent to `b` in normal mode, except that the motion never fails.
+    pub fn imap_shift_left<B: BufferLike + ?Sized>(
         &self,
         buffer: &B,
         mut cursor: Position,
     ) -> Result<ImapOutput, B::Error> {
         let mut buffer = ParsedBuffer::new(buffer, &self.tokenizer, true);
-        let mut motion = PreviousWord::default();
+        let mut motion = BackwardWord::new(false);
         let _ = motion.map(&mut buffer, 1, &mut cursor)?;
         Ok(ImapOutput { cursor })
     }

--- a/rust_backend/jieba_vim_rs_core/src/motion/imap_s_right.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/imap_s_right.rs
@@ -13,24 +13,35 @@
 // under the License.
 
 use crate::BufferLike;
-use crate::motion::core::motion::Motion;
 use crate::token::JiebaPlaceholder;
 
 use super::api::{ImapOutput, WordMotion};
 use super::core::buffer::ParsedBuffer;
+use super::core::motion::Motion;
 use super::core::position::Position;
-use super::primitives::text_object::PreviousWord;
+use super::primitives::text_object::ForwardWord;
 
 impl<C: JiebaPlaceholder> WordMotion<C> {
-    /// Delete the word before the cursor.
-    pub(crate) fn imap_ctrl_w_helper<B: BufferLike + ?Sized>(
+    /// Vim motion `S-Right` in insert mode. Take in `cursor` (0, lnum, col,
+    /// off, _), and return the new cursor position.
+    ///
+    /// # Basics
+    ///
+    /// Equivalent to `w` in normal mode, except that the motion never fails.
+    pub fn imap_shift_right<B: BufferLike + ?Sized>(
         &self,
         buffer: &B,
         mut cursor: Position,
     ) -> Result<ImapOutput, B::Error> {
         let mut buffer = ParsedBuffer::new(buffer, &self.tokenizer, true);
-        let mut motion = PreviousWord::default();
-        let _ = motion.map(&mut buffer, 1, &mut cursor)?;
+        let mut motion_eol = ForwardWord::new(true);
+        let mut motion_noeol = ForwardWord::new(false);
+        let mut cursor_copy = cursor;
+        let _ = motion_eol.map(&mut buffer, 1, &mut cursor)?;
+        let _ = motion_noeol.map(&mut buffer, 1, &mut cursor_copy)?;
+        if cursor_copy > cursor {
+            cursor = cursor_copy;
+        }
         Ok(ImapOutput { cursor })
     }
 }

--- a/rust_backend/jieba_vim_rs_core/src/motion/mod.rs
+++ b/rust_backend/jieba_vim_rs_core/src/motion/mod.rs
@@ -14,7 +14,11 @@
 
 mod api;
 pub(crate) mod core;
+mod imap_c_left;
+mod imap_c_right;
 mod imap_c_w;
+mod imap_s_left;
+mod imap_s_right;
 mod nmap_b;
 mod nmap_e;
 mod nmap_ge;
@@ -35,4 +39,4 @@ mod xmap_iw;
 mod xmap_w;
 
 pub use api::WordMotion;
-pub use api::ffi::{ImapCtrlWOutput, NmapOutput, OmapOutput, XmapOutput};
+pub use api::ffi::{ImapOutput, NmapOutput, OmapOutput, XmapOutput};

--- a/rust_backend/jieba_vim_rs_core/tests/golden_master.rs
+++ b/rust_backend/jieba_vim_rs_core/tests/golden_master.rs
@@ -263,23 +263,17 @@ fn run_test(dict: RecordDict) -> Result<(), Failed> {
         "imap" => {
             let motion: &[u8] = get_input(&dict.inputs, 0);
             let cursor = get_input(&dict.inputs, 1);
-            match motion {
-                // \<C-w>
-                b"\x17" | b"\\u0017" => match wm
-                    .imap_ctrl_w(&dict.buffer, cursor)
-                {
-                    Err(_) => {
-                        Err(format!("{}: failed to access buffer", dict.span)
-                            .into())
-                    }
-                    Ok(outputs) => assert_on_field(
-                        &dict.outputs,
-                        "cursor",
-                        &outputs.cursor,
-                        &dict.span,
-                    ),
-                },
-                _ => panic!("invalid motion: {:?}", motion),
+            match wm.imap(&dict.buffer, motion, cursor) {
+                Err(_) => {
+                    Err(format!("{}: failed to access buffer", dict.span)
+                        .into())
+                }
+                Ok(outputs) => assert_on_field(
+                    &dict.outputs,
+                    "cursor",
+                    &outputs.cursor,
+                    &dict.span,
+                ),
             }
         }
         f => panic!("unexpected func_name: {}", f),

--- a/rust_backend/jieba_vim_rs_core/tests/imap_arrow.rs
+++ b/rust_backend/jieba_vim_rs_core/tests/imap_arrow.rs
@@ -1,0 +1,125 @@
+// Copyright 2026 Kaiwen Wu. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy
+// of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+use jieba_vim_rs_core::motion::WordMotion;
+use jieba_vim_rs_core::token::Tokenizer;
+
+mod keyword_cutter;
+use keyword_cutter::KeywordCutter;
+
+const CTRL_RIGHT: &[u8] = b"\x80\xfdV";
+const CTRL_LEFT: &[u8] = b"\x80\xfdU";
+const SHIFT_RIGHT: &[u8] = b"\x80%i";
+const SHIFT_LEFT: &[u8] = b"\x80#4";
+
+#[test]
+fn test_imap_ctrl_right() {
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let buffer = vec!["f,o".into()];
+
+    let output = wm.imap(&buffer, CTRL_RIGHT, [0, 1, 1, 0, 1]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 4, 0]);
+
+    let output = wm.imap(&buffer, CTRL_RIGHT, [0, 1, 4, 0, 4]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 4, 0]);
+
+    let buffer = vec!["foo".into(), "bar".into()];
+
+    let output = wm.imap(&buffer, CTRL_RIGHT, [0, 1, 1, 0, 1]).unwrap();
+    assert_eq!(output.cursor, [0, 2, 1, 0]);
+
+    let output = wm.imap(&buffer, CTRL_RIGHT, [0, 1, 3, 0, 3]).unwrap();
+    assert_eq!(output.cursor, [0, 2, 1, 0]);
+
+    let output = wm.imap(&buffer, CTRL_RIGHT, [0, 1, 4, 0, 4]).unwrap();
+    assert_eq!(output.cursor, [0, 2, 1, 0]);
+
+    let output = wm.imap(&buffer, CTRL_RIGHT, [0, 2, 1, 0, 1]).unwrap();
+    assert_eq!(output.cursor, [0, 2, 4, 0]);
+}
+
+#[test]
+fn test_imap_shift_right() {
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let buffer = vec!["f,o".into()];
+
+    let output = wm.imap(&buffer, SHIFT_RIGHT, [0, 1, 1, 0, 1]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 2, 0]);
+
+    let buffer = vec!["foo".into()];
+
+    let output = wm.imap(&buffer, SHIFT_RIGHT, [0, 1, 1, 0, 1]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 4, 0]);
+
+    let output = wm.imap(&buffer, SHIFT_RIGHT, [0, 1, 4, 0, 4]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 4, 0]);
+
+    let buffer = vec!["foo".into(), "bar".into()];
+
+    let output = wm.imap(&buffer, SHIFT_RIGHT, [0, 1, 1, 0, 1]).unwrap();
+    assert_eq!(output.cursor, [0, 2, 1, 0]);
+
+    let output = wm.imap(&buffer, SHIFT_RIGHT, [0, 1, 3, 0, 3]).unwrap();
+    assert_eq!(output.cursor, [0, 2, 1, 0]);
+
+    let output = wm.imap(&buffer, SHIFT_RIGHT, [0, 1, 4, 0, 4]).unwrap();
+    assert_eq!(output.cursor, [0, 2, 1, 0]);
+
+    let output = wm.imap(&buffer, SHIFT_RIGHT, [0, 2, 1, 0, 1]).unwrap();
+    assert_eq!(output.cursor, [0, 2, 4, 0]);
+}
+
+#[test]
+fn test_imap_ctrl_left() {
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let buffer = vec!["f,o".into()];
+
+    let output = wm.imap(&buffer, CTRL_LEFT, [0, 1, 4, 0, 4]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 1, 0]);
+
+    let output = wm.imap(&buffer, CTRL_LEFT, [0, 1, 3, 0, 3]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 1, 0]);
+}
+
+#[test]
+fn test_imap_shift_left() {
+    let mut wm = WordMotion::new(
+        Tokenizer::try_new(KeywordCutter::new([]), "@,48-57,_,192-255")
+            .unwrap(),
+    );
+    let buffer = vec!["f,o".into()];
+
+    let output = wm.imap(&buffer, SHIFT_LEFT, [0, 1, 4, 0, 4]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 3, 0]);
+
+    let output = wm.imap(&buffer, SHIFT_LEFT, [0, 1, 3, 0, 3]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 2, 0]);
+
+    let buffer = vec!["foo".into()];
+
+    let output = wm.imap(&buffer, SHIFT_LEFT, [0, 1, 4, 0, 4]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 1, 0]);
+
+    let output = wm.imap(&buffer, SHIFT_LEFT, [0, 1, 3, 0, 3]).unwrap();
+    assert_eq!(output.cursor, [0, 1, 1, 0]);
+}

--- a/test/cases/basic_integrated_verification/buffers.yaml
+++ b/test/cases/basic_integrated_verification/buffers.yaml
@@ -527,6 +527,14 @@ insert_eol_buffers:
   - '␊␊······|␊␊'
   - '␊␊······␊|␊'
 
+insert_forward_eol_buffers:
+  - '|a␊'
+  - 'ab|cd␊'
+  - '|····␊'
+  - 'abcde···|fgh␊'
+  - '···abcde·|··␊'
+  - '␊␊····|··␊'
+
 nvim_basics:
   buffers:
     - 'abcd·efghi···j|kl·m···nopqr··␊'

--- a/test/cases/basic_integrated_verification/main.jieba_test_case.j2
+++ b/test/cases/basic_integrated_verification/main.jieba_test_case.j2
@@ -156,7 +156,7 @@ S1 "a= '[= ']= '<= '>=
 {%- endfor %}
 
 {%- for key in ['\\<C-Left>', '\\<C-Right>', '\\<S-Left>', '\\<S-Right>'] %}
-  {%- for buffer in nvim_basics.buffers %}
+  {%- for buffer in forward_buffers + backward_buffers + insert_eol_buffers + insert_forward_eol_buffers %}
 
 // It's a known bug that arrow imaps will incorrectly set `[ and `] marks
 // (https://github.com/kkew3/jieba.vim/pull/134), and so tests against these

--- a/test/cases/basic_integrated_verification/main.jieba_test_case.j2
+++ b/test/cases/basic_integrated_verification/main.jieba_test_case.j2
@@ -158,6 +158,9 @@ S1 "a= '[= ']= '<= '>=
 {%- for key in ['\\<C-Left>', '\\<C-Right>', '\\<S-Left>', '\\<S-Right>'] %}
   {%- for buffer in nvim_basics.buffers %}
 
+// It's a known bug that arrow imaps will incorrectly set `[ and `] marks
+// (https://github.com/kkew3/jieba.vim/pull/134), and so tests against these
+// marks are not included here.
 M i
 K {{ key }}
 B0 {{ buffer }}

--- a/test/cases/basic_integrated_verification/main.jieba_test_case.j2
+++ b/test/cases/basic_integrated_verification/main.jieba_test_case.j2
@@ -32,7 +32,7 @@
 #E TextChangedI=
 #E TextYankPost=
 
-{%- for key in ['w', 'e'] %}
+{%- for key in ['w', 'e', '\\<C-Right>', '\\<S-Right>'] %}
   {%- for count in [0, 1, 2, 3, 4, 10293949403] %}
     {%- for buffer in forward_buffers %}
 
@@ -71,7 +71,7 @@ S1 visualmode()= '[= ']=
   {%- endfor %}
 {%- endfor %}
 
-{%- for key in ['b', 'ge'] %}
+{%- for key in ['b', 'ge', '\\<C-Left>', '\\<S-Left>'] %}
   {%- for count in [0, 1, 2, 3, 4, 10293949403] %}
     {%- for buffer in backward_buffers %}
 
@@ -152,6 +152,15 @@ S0 backspace=indent,eol,start
 K {{ key }}
 B0 {{ buffer }}
 S1 "a= '[= ']= '<= '>=
+  {%- endfor %}
+{%- endfor %}
+
+{%- for key in ['\\<C-Left>', '\\<C-Right>', '\\<S-Left>', '\\<S-Right>'] %}
+  {%- for buffer in nvim_basics.buffers %}
+
+M i
+K {{ key }}
+B0 {{ buffer }}
   {%- endfor %}
 {%- endfor %}
 

--- a/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
+++ b/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
@@ -95,6 +95,9 @@ S1 "a= '[= ']= '<= '>=
 {%- for key in ['\\<C-Left>', '\\<C-Right>', '\\<S-Left>', '\\<S-Right>'] %}
   {%- for buffer in nvim_basics.buffers %}
 
+// It's a known bug that arrow imaps will incorrectly set `[ and `] marks
+// (https://github.com/kkew3/jieba.vim/pull/134), and so tests against these
+// marks are not included here.
 M i
 K {{ key }}
 B0 {{ buffer }}

--- a/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
+++ b/test/cases/basic_integrated_verification/nvim_basics.jieba_test_case.j2
@@ -22,7 +22,7 @@
 #E InsertLeave=
 #E TextYankPost=
 
-{%- for key in ['w', 'e', 'b', 'ge'] %}
+{%- for key in ['w', 'e', 'b', 'ge', '\\<C-Left>', '\\<C-Right>', '\\<S-Left>', '\\<S-Right>'] %}
   {%- for count in [0, 1, 2, 3, 4, 10293949403] %}
     {%- for buffer in nvim_basics.buffers %}
 
@@ -91,3 +91,14 @@ B0 {{ buffer }}
 S1 "a= '[= ']= '<= '>=
   {%- endfor %}
 {%- endfor %}
+
+{%- for key in ['\\<C-Left>', '\\<C-Right>', '\\<S-Left>', '\\<S-Right>'] %}
+  {%- for buffer in nvim_basics.buffers %}
+
+M i
+K {{ key }}
+B0 {{ buffer }}
+  {%- endfor %}
+{%- endfor %}
+
+// vim: ft=jieba_test_case

--- a/test/jieba_test_metatest/src/jieba_test_metatest/basic_integrated_verification.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/basic_integrated_verification.py
@@ -334,9 +334,6 @@ endfunction
         )
         outfile.write(f"""\
 " define mapping
-function! JiebaOmapExpr(motion, model_funcname)
-    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
-endfunction
 {self.mode}noremap <expr> <silent> {motion_key_unescaped} {expr_func}("{self.motion_key}", "JiebaOracleModel")
 
 """)
@@ -467,13 +464,25 @@ endfunction
         # Cursor movement.
         outfile.write('" cursor movement\n')
         if self.mode == "n":
-            outfile.write(f"normal! {self.count}{self.motion_key}\n")
+            outfile.write(
+                "execute {cmd_str}\n".format(
+                    cmd_str=vim.lit(f"normal! {self.count}{self.motion_key}")
+                )
+            )
         elif self.mode == "x":
-            outfile.write(f"normal! gv{self.count}{self.motion_key}\n")
+            outfile.write(
+                "execute {cmd_str}\n".format(
+                    cmd_str=vim.lit(f"normal! gv{self.count}{self.motion_key}")
+                )
+            )
         elif self.mode == "o":
             reg = f'"{self.register}' if self.register else ""
             outfile.write(
-                f"normal! {reg}{self.operator}{self.count}{self.motion_key}\n"
+                "execute {cmd_str}\n".format(
+                    cmd_str=vim.lit(
+                        f"normal! {reg}{self.operator}{self.count}{self.motion_key}"
+                    )
+                )
             )
         else:
             outfile.write(f"""\
@@ -569,13 +578,25 @@ silent execute "source " . expand("%:p:h") . "/Session.vim"
         # Cursor movement.
         outfile.write('" cursor movement\n')
         if self.mode == "n":
-            outfile.write(f"normal {self.count}{self.motion_key}\n")
+            outfile.write(
+                "execute {cmd_str}\n".format(
+                    cmd_str=vim.lit(f"normal {self.count}{self.motion_key}")
+                )
+            )
         elif self.mode == "x":
-            outfile.write(f"normal gv{self.count}{self.motion_key}\n")
+            outfile.write(
+                "execute {cmd_str}\n".format(
+                    cmd_str=vim.lit(f"normal gv{self.count}{self.motion_key}")
+                )
+            )
         elif self.mode == "o":
             reg = f'"{self.register}' if self.register else ""
             outfile.write(
-                f"normal {reg}{self.operator}{self.count}{self.motion_key}\n"
+                "execute {cmd_str}\n".format(
+                    cmd_str=vim.lit(
+                        f"normal {reg}{self.operator}{self.count}{self.motion_key}"
+                    )
+                )
             )
         else:
             outfile.write(f"""\

--- a/test/jieba_test_metatest/src/jieba_test_metatest/basic_integrated_verification.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/basic_integrated_verification.py
@@ -312,8 +312,10 @@ EOF
         }[self.mode]
         outfile.write(f"""\
 " define oracle model
+let s:map_motions = {{"\\<C-Left>": "\\\\u0080\\\\u00fdU", "\\<C-Right>": "\\\\u0080\\\\u00fdV", "\\<S-Left>": "\\\\u0080#4", "\\<S-Right>": "\\\\u0080%i"}}
 function! JiebaOracleModel(...)
-    let g:model_input = a:000
+    let g:model_input = copy(a:000)
+    let g:model_input[0] = get(s:map_motions, g:model_input[0], g:model_input[0])
     let g:model_output = call(function("{func}"), a:000)
     return g:model_output
 endfunction

--- a/test/jieba_test_metatest/src/jieba_test_metatest/integrated_test.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/integrated_test.py
@@ -215,18 +215,25 @@ class IntegratedBlock:
         outfile.write("\n")
 
         # Define jieba mappings.
+        map_names = {
+            "\\<C-w>": "C_w",
+            "\\<C-Left>": "C_Left",
+            "\\<C-Right": "C_Right",
+            "\\<S-Left>": "S_Left",
+            "\\<S-Right>": "S_Right",
+        }
         for k in WORD_MOTION_KEYS:
+            k_unescaped = k[1:] if k.startswith("\\<") else k
             outfile.write(f"""\
-nmap {k} <Plug>(Jieba_{k})
-xmap {k} <Plug>(Jieba_{k})
-omap {k} <Plug>(Jieba_{k})
+nmap {k_unescaped} <Plug>(Jieba_{map_names.get(k, k)})
+xmap {k_unescaped} <Plug>(Jieba_{map_names.get(k, k)})
+omap {k_unescaped} <Plug>(Jieba_{map_names.get(k, k)})
 """)
         for k in WORD_TEXT_OBJECTS:
             outfile.write(f"""\
 xmap {k} <Plug>(Jieba_{k})
 omap {k} <Plug>(Jieba_{k})
 """)
-        map_names = {"\\<C-w>": "C_w"}
         for k in WORD_MOTION_INSERT_KEYS:
             k_unescaped = k[1:] if k.startswith("\\<") else k
             outfile.write(

--- a/test/jieba_test_metatest/src/jieba_test_metatest/motion_keys.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/motion_keys.py
@@ -13,6 +13,25 @@
 # the License.
 
 
-WORD_MOTION_KEYS = ["w", "W", "e", "E", "b", "B", "ge", "gE"]
+WORD_MOTION_KEYS = [
+    "w",
+    "W",
+    "e",
+    "E",
+    "b",
+    "B",
+    "ge",
+    "gE",
+    "\\<C-Left>",
+    "\\<C-Right>",
+    "\\<S-Left>",
+    "\\<S-Right>",
+]
 WORD_TEXT_OBJECTS = ["iw", "iW", "aw", "aW"]
-WORD_MOTION_INSERT_KEYS = ["\\<C-w>"]
+WORD_MOTION_INSERT_KEYS = [
+    "\\<C-w>",
+    "\\<C-Left>",
+    "\\<C-Right>",
+    "\\<S-Left>",
+    "\\<S-Right>",
+]

--- a/test/jieba_test_metatest/src/jieba_test_metatest/test_basic_integrated_verification.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/test_basic_integrated_verification.py
@@ -425,8 +425,10 @@ EOF
 endif
 
 " define oracle model
+let s:map_motions = {"\\<C-Left>": "\\\\u0080\\\\u00fdU", "\\<C-Right>": "\\\\u0080\\\\u00fdV", "\\<S-Left>": "\\\\u0080#4", "\\<S-Right>": "\\\\u0080%i"}
 function! JiebaOracleModel(...)
-    let g:model_input = a:000
+    let g:model_input = copy(a:000)
+    let g:model_input[0] = get(s:map_motions, g:model_input[0], g:model_input[0])
     let g:model_output = call(function("JiebaModelNmap"), a:000)
     return g:model_output
 endfunction
@@ -521,8 +523,10 @@ endif
 silent execute "source " . expand("%:p:h") . "/Session.vim"
 
 " define oracle model
+let s:map_motions = {"\\<C-Left>": "\\\\u0080\\\\u00fdU", "\\<C-Right>": "\\\\u0080\\\\u00fdV", "\\<S-Left>": "\\\\u0080#4", "\\<S-Right>": "\\\\u0080%i"}
 function! JiebaOracleModel(...)
-    let g:model_input = a:000
+    let g:model_input = copy(a:000)
+    let g:model_input[0] = get(s:map_motions, g:model_input[0], g:model_input[0])
     let g:model_output = call(function("JiebaModelNmap"), a:000)
     return g:model_output
 endfunction
@@ -654,8 +658,10 @@ EOF
 endif
 
 " define oracle model
+let s:map_motions = {"\\<C-Left>": "\\\\u0080\\\\u00fdU", "\\<C-Right>": "\\\\u0080\\\\u00fdV", "\\<S-Left>": "\\\\u0080#4", "\\<S-Right>": "\\\\u0080%i"}
 function! JiebaOracleModel(...)
-    let g:model_input = a:000
+    let g:model_input = copy(a:000)
+    let g:model_input[0] = get(s:map_motions, g:model_input[0], g:model_input[0])
     let g:model_output = call(function("JiebaModelXmap"), a:000)
     return g:model_output
 endfunction
@@ -755,8 +761,10 @@ endif
 silent execute "source " . expand("%:p:h") . "/Session.vim"
 
 " define oracle model
+let s:map_motions = {"\\<C-Left>": "\\\\u0080\\\\u00fdU", "\\<C-Right>": "\\\\u0080\\\\u00fdV", "\\<S-Left>": "\\\\u0080#4", "\\<S-Right>": "\\\\u0080%i"}
 function! JiebaOracleModel(...)
-    let g:model_input = a:000
+    let g:model_input = copy(a:000)
+    let g:model_input[0] = get(s:map_motions, g:model_input[0], g:model_input[0])
     let g:model_output = call(function("JiebaModelXmap"), a:000)
     return g:model_output
 endfunction
@@ -933,8 +941,10 @@ EOF
 endif
 
 " define oracle model
+let s:map_motions = {"\\<C-Left>": "\\\\u0080\\\\u00fdU", "\\<C-Right>": "\\\\u0080\\\\u00fdV", "\\<S-Left>": "\\\\u0080#4", "\\<S-Right>": "\\\\u0080%i"}
 function! JiebaOracleModel(...)
-    let g:model_input = a:000
+    let g:model_input = copy(a:000)
+    let g:model_input[0] = get(s:map_motions, g:model_input[0], g:model_input[0])
     let g:model_output = call(function("JiebaModelOmap"), a:000)
     return g:model_output
 endfunction
@@ -1005,8 +1015,10 @@ endif
 silent execute "source " . expand("%:p:h") . "/Session.vim"
 
 " define oracle model
+let s:map_motions = {"\\<C-Left>": "\\\\u0080\\\\u00fdU", "\\<C-Right>": "\\\\u0080\\\\u00fdV", "\\<S-Left>": "\\\\u0080#4", "\\<S-Right>": "\\\\u0080%i"}
 function! JiebaOracleModel(...)
-    let g:model_input = a:000
+    let g:model_input = copy(a:000)
+    let g:model_input[0] = get(s:map_motions, g:model_input[0], g:model_input[0])
     let g:model_output = call(function("JiebaModelOmap"), a:000)
     return g:model_output
 endfunction

--- a/test/jieba_test_metatest/src/jieba_test_metatest/test_basic_integrated_verification.py
+++ b/test/jieba_test_metatest/src/jieba_test_metatest/test_basic_integrated_verification.py
@@ -432,9 +432,6 @@ function! JiebaOracleModel(...)
 endfunction
 
 " define mapping
-function! JiebaOmapExpr(motion, model_funcname)
-    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
-endfunction
 nnoremap <expr> <silent> w JiebaNmapExpr("w", "JiebaOracleModel")
 
 " state_before setup
@@ -488,7 +485,7 @@ endif
 
 let g:jieba_test_case_events_count = {}
 " cursor movement
-normal! w
+execute "normal! w"
 execute "normal! \\<Esc>"
 
 let s:jieba_test_case_events_count_frozen = copy(g:jieba_test_case_events_count)
@@ -531,9 +528,6 @@ function! JiebaOracleModel(...)
 endfunction
 
 " define mapping
-function! JiebaOmapExpr(motion, model_funcname)
-    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
-endfunction
 nnoremap <expr> <silent> w JiebaNmapExpr("w", "JiebaOracleModel")
 
 " state_before setup
@@ -587,7 +581,7 @@ endif
 
 let g:jieba_test_case_events_count = {}
 " cursor movement
-normal w
+execute "normal w"
 execute "normal! \\<Esc>"
 
 let g:jieba_test_case_events_count_frozen = copy(g:jieba_test_case_events_count)
@@ -667,9 +661,6 @@ function! JiebaOracleModel(...)
 endfunction
 
 " define mapping
-function! JiebaOmapExpr(motion, model_funcname)
-    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
-endfunction
 xnoremap <expr> <silent> e JiebaXmapExpr("e", "JiebaOracleModel")
 
 " state_before setup
@@ -723,7 +714,7 @@ endif
 
 let g:jieba_test_case_events_count = {}
 " cursor movement
-normal! gv1e
+execute "normal! gv1e"
 execute "normal! \\<Esc>"
 
 let s:jieba_test_case_events_count_frozen = copy(g:jieba_test_case_events_count)
@@ -771,9 +762,6 @@ function! JiebaOracleModel(...)
 endfunction
 
 " define mapping
-function! JiebaOmapExpr(motion, model_funcname)
-    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
-endfunction
 xnoremap <expr> <silent> e JiebaXmapExpr("e", "JiebaOracleModel")
 
 " state_before setup
@@ -827,7 +815,7 @@ endif
 
 let g:jieba_test_case_events_count = {}
 " cursor movement
-normal gv1e
+execute "normal gv1e"
 execute "normal! \\<Esc>"
 
 let g:jieba_test_case_events_count_frozen = copy(g:jieba_test_case_events_count)
@@ -952,9 +940,6 @@ function! JiebaOracleModel(...)
 endfunction
 
 " define mapping
-function! JiebaOmapExpr(motion, model_funcname)
-    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
-endfunction
 onoremap <expr> <silent> W JiebaOmapExpr("W", "JiebaOracleModel")
 
 " state_before setup
@@ -980,7 +965,7 @@ call setpos("'z", [0, 0, 0, 0])
 
 let g:jieba_test_case_events_count = {}
 " cursor movement
-normal! "ad2W
+execute "normal! \\"ad2W"
 execute "normal! \\<Esc>"
 
 let s:jieba_test_case_events_count_frozen = copy(g:jieba_test_case_events_count)
@@ -1027,9 +1012,6 @@ function! JiebaOracleModel(...)
 endfunction
 
 " define mapping
-function! JiebaOmapExpr(motion, model_funcname)
-    return JiebaOmapRepeatExpr(a:motion, 0, a:model_funcname)
-endfunction
 onoremap <expr> <silent> W JiebaOmapExpr("W", "JiebaOracleModel")
 
 " state_before setup
@@ -1055,7 +1037,7 @@ call setpos("'z", [0, 0, 0, 0])
 
 let g:jieba_test_case_events_count = {}
 " cursor movement
-normal "ad2W
+execute "normal \\"ad2W"
 execute "normal! \\<Esc>"
 
 let g:jieba_test_case_events_count_frozen = copy(g:jieba_test_case_events_count)


### PR DESCRIPTION
Known bugs:

- Arrow mappings for imap incorrectly set `` `[ `` and `` `] `` marks. Hence, these imaps are not enabled when `jieba_vim_keymap = 1`.

Closes #98.