### PR TITLE
Fix tagging target in release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -336,6 +336,7 @@ jobs:
           files: |
             jieba_vim_rs-*
           tag_name: ${{ needs.check-for-release.outputs.release-tag-name }}
+          target_commitish: release
           prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request aims to fix the issue where tag is created on 'main' branch rather than 'release'.