### PR TITLE
Bump pyo3 to 0.29 and the minimum python3 version to 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v2.x.x
+
+Dev:
+
+- Bump the minimum python3 version to 3.8 ([#148]).
+
+[#148]: https://github.com/kkew3/jieba.vim/pull/148
+
+
 ## v2.2.0 - 2026-08-09
 
 Features:

--- a/rust_backend/Cargo.lock
+++ b/rust_backend/Cargo.lock
@@ -434,12 +434,12 @@ dependencies = [
 
 [[package]]
 name = "jieba_vim_rs_binding_py3"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "jieba-rs",
  "jieba_vim_rs_core",
  "pyo3",
- "pyo3-build-config 0.29.2",
+ "pyo3-build-config",
 ]
 
 [[package]]
@@ -752,25 +752,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.28.3",
+ "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
-dependencies = [
- "target-lexicon",
 ]
 
 [[package]]
@@ -784,19 +775,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
- "pyo3-build-config 0.28.3",
+ "pyo3-build-config",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -806,13 +797,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config 0.28.3",
  "quote",
  "syn 2.0.117",
 ]

--- a/rust_backend/jieba_vim_rs_binding_py3/Cargo.toml
+++ b/rust_backend/jieba_vim_rs_binding_py3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jieba_vim_rs_binding_py3"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,9 +10,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 # Put vim-compatible python abi in pyo3 features.
-pyo3 = { version = "0.28.3", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.29.2", features = ["extension-module", "abi3-py38"] }
 jieba-rs = { version = "0.10.2" }
 jieba_vim_rs_core = { path = "../jieba_vim_rs_core" }
 
 [build-dependencies]
-pyo3-build-config = "0.29.0"
+pyo3-build-config = "0.29.2"


### PR DESCRIPTION
Considering that python 3.8 is preinstalled in Ubuntu 20.04 LTS, and the standard support of Ubuntu 18.04 LTS, the edition without python 3.8, has long ended as of Sep 2026, the decision to bump pyo3 and the minimum python3 version should not affect most users.